### PR TITLE
REDTWOO-30: Add missing conversion ID in PageVisit Conversion event

### DIFF
--- a/includes/Tracking/ConversionEvent/PageVisitEvent.php
+++ b/includes/Tracking/ConversionEvent/PageVisitEvent.php
@@ -38,11 +38,15 @@ final class PageVisitEvent extends EventPayloadBase implements ConversionEventIn
 	 * @return array<string,mixed> Conversion event payload.
 	 */
 	public function build_payload( array $args = array() ): array {
-		$base    = parent::build_payload();
-		$default = array(
-			'event_type' => array(
+		$meta_data = array(
+			'conversion_id' => $args['conversion_id'] ?? '',
+		);
+		$base      = parent::build_payload();
+		$default   = array(
+			'event_type'     => array(
 				'tracking_type' => self::ID,
 			),
+			'event_metadata' => $meta_data,
 		);
 
 		return array_merge( $base, $default, $args['user_data'] );


### PR DESCRIPTION
Closes: https://linear.app/a8c/issue/REDTWOO-30/conversion-id-missing-for-pagevisit-event