### PR TITLE
REDTWOO-28: Add a notice to inform users about the Catalog Manager role and catalog creation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,6 +40,8 @@ module.exports = {
 		getComputedStyle: 'readonly',
 		wp_has_consent: 'readonly',
 		jQuery: 'readonly',
+		ajaxurl: 'readonly',
+		redditAdsAdminData: 'readonly',
 	},
 	rules: {
 		'@wordpress/i18n-text-domain': [

--- a/includes/API/Site/Controllers/RedditConnectionController.php
+++ b/includes/API/Site/Controllers/RedditConnectionController.php
@@ -597,6 +597,7 @@ class RedditConnectionController extends RESTBaseController {
 				array(
 					'status'  => 'error',
 					'message' => $response->get_error_message(),
+					'data'    => $response->get_error_data(),
 				),
 				500
 			);

--- a/includes/API/Site/Controllers/RedditConnectionController.php
+++ b/includes/API/Site/Controllers/RedditConnectionController.php
@@ -15,6 +15,7 @@
 
 namespace RedditForWooCommerce\API\Site\Controllers;
 
+use RedditForWooCommerce\Admin\Export\Service\ProductExportService;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_Error;
@@ -26,6 +27,8 @@ use RedditForWooCommerce\Utils\Storage\Transients;
 use RedditForWooCommerce\Utils\Storage\TransientDefaults;
 use RedditForWooCommerce\Utils\Helper;
 use RedditForWooCommerce\API\AdPartner\AdPartnerApi;
+use RedditForWooCommerce\ServiceContainer;
+use RedditForWooCommerce\ServiceKey;
 
 /**
  * Controller for setting up and managing the Reddit account connection.
@@ -134,6 +137,16 @@ class RedditConnectionController extends RESTBaseController {
 			array(
 				'methods'             => 'GET',
 				'callback'            => array( $this, 'get_pixels' ),
+				'permission_callback' => array( $this, 'permissions_check' ),
+			)
+		);
+
+		register_rest_route(
+			Config::REST_NAMESPACE . '/reddit',
+			'catalog',
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( $this, 'create_catalog' ),
 				'permission_callback' => array( $this, 'permissions_check' ),
 			)
 		);
@@ -546,6 +559,76 @@ class RedditConnectionController extends RESTBaseController {
 		);
 
 		return rest_ensure_response( $formatted );
+	}
+
+	/**
+	 * Creates a product catalog for the current business.
+	 *
+	 * This method creates a product catalog for the current business and
+	 * triggers the feed creation if the export is completed and the export file URL is set.
+	 * Triggers the export if the export is not in progress and the export file URL is not set.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function create_catalog() {
+		// Bail early if the catalog already exists.
+		$catalog_id = Options::get( OptionDefaults::CATALOG_ID );
+		if ( $catalog_id ) {
+			return new WP_REST_Response(
+				array(
+					'status'  => 'error',
+					'message' => __( 'Catalog already exists.', 'reddit-for-woocommerce' ),
+				),
+				400
+			);
+		}
+
+		// Create the catalog.
+		$response = $this->ad_partner_api->catalog->create();
+
+		if ( is_wp_error( $response ) ) {
+			$logger = wc_get_logger();
+			$logger->alert(
+				'Catalog creation failed with error code' . $response->get_error_code(),
+			);
+			return new WP_REST_Response(
+				array(
+					'status'  => 'error',
+					'message' => $response->get_error_message(),
+				),
+				500
+			);
+		}
+
+		$data         = $response->get_data();
+		$catalog_data = $data['data'] ?? array();
+
+		if ( ! empty( $catalog_data ) ) {
+			Options::set( OptionDefaults::CATALOG_ID, $catalog_data['id'] );
+
+			$is_job_in_progress = ServiceContainer::get( ServiceKey::PRODUCT_EXPORT_SERVICE )->job->is_job_in_progress( ProductExportService::ACTION_HOOK );
+			$file_url           = Options::get( OptionDefaults::EXPORT_FILE_URL );
+
+			if ( ! $is_job_in_progress && ! empty( $file_url ) ) {
+				// Trigger feed creation if the export is completed.
+				ServiceContainer::get( ServiceKey::PRODUCT_EXPORT_SERVICE )->create_feed();
+			} elseif ( ! $is_job_in_progress && empty( $file_url ) ) {
+				// Trigger export if the export is not in progress and the export file URL is not set.
+				ServiceContainer::get( ServiceKey::PRODUCT_EXPORT_SERVICE )->start_export();
+			}
+		}
+
+		return rest_ensure_response(
+			array(
+				'status'  => 'success',
+				'data'    => array(
+					'id' => $catalog_data['id'],
+				),
+				'message' => __( 'Catalog created successfully.', 'reddit-for-woocommerce' ),
+			)
+		);
 	}
 
 	/**

--- a/includes/API/Site/Controllers/RedditConnectionController.php
+++ b/includes/API/Site/Controllers/RedditConnectionController.php
@@ -15,7 +15,6 @@
 
 namespace RedditForWooCommerce\API\Site\Controllers;
 
-use RedditForWooCommerce\Admin\Export\Service\ProductExportService;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_Error;
@@ -27,8 +26,6 @@ use RedditForWooCommerce\Utils\Storage\Transients;
 use RedditForWooCommerce\Utils\Storage\TransientDefaults;
 use RedditForWooCommerce\Utils\Helper;
 use RedditForWooCommerce\API\AdPartner\AdPartnerApi;
-use RedditForWooCommerce\ServiceContainer;
-use RedditForWooCommerce\ServiceKey;
 
 /**
  * Controller for setting up and managing the Reddit account connection.

--- a/includes/API/Site/Controllers/RedditConnectionController.php
+++ b/includes/API/Site/Controllers/RedditConnectionController.php
@@ -140,16 +140,6 @@ class RedditConnectionController extends RESTBaseController {
 				'permission_callback' => array( $this, 'permissions_check' ),
 			)
 		);
-
-		register_rest_route(
-			Config::REST_NAMESPACE . '/reddit',
-			'catalog',
-			array(
-				'methods'             => 'POST',
-				'callback'            => array( $this, 'create_catalog' ),
-				'permission_callback' => array( $this, 'permissions_check' ),
-			)
-		);
 	}
 
 	/**
@@ -559,77 +549,6 @@ class RedditConnectionController extends RESTBaseController {
 		);
 
 		return rest_ensure_response( $formatted );
-	}
-
-	/**
-	 * Creates a product catalog for the current business.
-	 *
-	 * This method creates a product catalog for the current business and
-	 * triggers the feed creation if the export is completed and the export file URL is set.
-	 * Triggers the export if the export is not in progress and the export file URL is not set.
-	 *
-	 * @since 0.1.0
-	 *
-	 * @return WP_REST_Response
-	 */
-	public function create_catalog() {
-		// Bail early if the catalog already exists.
-		$catalog_id = Options::get( OptionDefaults::CATALOG_ID );
-		if ( $catalog_id ) {
-			return new WP_REST_Response(
-				array(
-					'status'  => 'error',
-					'message' => __( 'Catalog already exists.', 'reddit-for-woocommerce' ),
-				),
-				400
-			);
-		}
-
-		// Create the catalog.
-		$response = $this->ad_partner_api->catalog->create();
-
-		if ( is_wp_error( $response ) ) {
-			$logger = wc_get_logger();
-			$logger->alert(
-				'Catalog creation failed with error code' . $response->get_error_code(),
-			);
-			return new WP_REST_Response(
-				array(
-					'status'  => 'error',
-					'message' => $response->get_error_message(),
-					'data'    => $response->get_error_data(),
-				),
-				500
-			);
-		}
-
-		$data         = $response->get_data();
-		$catalog_data = $data['data'] ?? array();
-
-		if ( ! empty( $catalog_data ) ) {
-			Options::set( OptionDefaults::CATALOG_ID, $catalog_data['id'] );
-
-			$is_job_in_progress = ServiceContainer::get( ServiceKey::PRODUCT_EXPORT_SERVICE )->job->is_job_in_progress( ProductExportService::ACTION_HOOK );
-			$file_url           = Options::get( OptionDefaults::EXPORT_FILE_URL );
-
-			if ( ! $is_job_in_progress && ! empty( $file_url ) ) {
-				// Trigger feed creation if the export is completed.
-				ServiceContainer::get( ServiceKey::PRODUCT_EXPORT_SERVICE )->create_feed();
-			} elseif ( ! $is_job_in_progress && empty( $file_url ) ) {
-				// Trigger export if the export is not in progress and the export file URL is not set.
-				ServiceContainer::get( ServiceKey::PRODUCT_EXPORT_SERVICE )->start_export();
-			}
-		}
-
-		return rest_ensure_response(
-			array(
-				'status'  => 'success',
-				'data'    => array(
-					'id' => $catalog_data['id'],
-				),
-				'message' => __( 'Catalog created successfully.', 'reddit-for-woocommerce' ),
-			)
-		);
 	}
 
 	/**

--- a/includes/API/Site/Controllers/SettingsController.php
+++ b/includes/API/Site/Controllers/SettingsController.php
@@ -121,6 +121,7 @@ class SettingsController extends RESTBaseController {
 				'last_export_timestamp' => Helper::get_formatted_timestamp( $timestamp ),
 				'export_file_url'       => file_exists( $csv_path ) ? Options::get( OptionDefaults::EXPORT_FILE_URL ) : '',
 				'products_token'        => Options::get( OptionDefaults::WCS_PRODUCTS_TOKEN ),
+				'catalog_id'            => Options::get( OptionDefaults::CATALOG_ID ),
 			)
 		);
 	}

--- a/includes/Admin/Assets.php
+++ b/includes/Admin/Assets.php
@@ -82,6 +82,7 @@ class Assets {
 				'exportFileUrl'      => file_exists( $csv_path ) ? Options::get( OptionDefaults::EXPORT_FILE_URL ) : '',
 				'lastTimestamp'      => Helper::get_formatted_timestamp( Options::get( OptionDefaults::LAST_EXPORT_TIMESTAMP ) ),
 				'slug'               => 'rfw',
+				'prefix'             => Helper::with_prefix( '' ),
 			)
 		);
 	}

--- a/includes/Admin/Export/Service/ProductExportService.php
+++ b/includes/Admin/Export/Service/ProductExportService.php
@@ -122,7 +122,8 @@ class ProductExportService {
 
 		Helper::register_ajax_action(
 			'create_catalog',
-			array( $this, 'create_catalog_manually' )
+			array( $this, 'create_catalog_manually' ),
+			true
 		);
 	}
 
@@ -422,15 +423,16 @@ class ProductExportService {
 	 * Triggers the export if the export is not in progress and the export file URL is not set.
 	 *
 	 * @since 0.1.0
-	 *
-	 * @return WP_REST_Response
 	 */
-	public function create_catalog_manually() {
+	public function create_catalog_manually(): void {
 		// Bail early if the catalog already exists.
 		$catalog_id = Options::get( OptionDefaults::CATALOG_ID );
+
 		if ( $catalog_id ) {
 			wp_send_json_error(
-				__( 'Catalog already exists.', 'reddit-for-woocommerce' )
+				array(
+					'message' => __( 'Catalog already exists.', 'reddit-for-woocommerce' ),
+				)
 			);
 		}
 
@@ -446,7 +448,6 @@ class ProductExportService {
 			wp_send_json_error(
 				array(
 					'message' => $response->get_error_message(),
-					'data'    => $response->get_error_data(),
 				)
 			);
 		}
@@ -472,9 +473,7 @@ class ProductExportService {
 		wp_send_json_success(
 			array(
 				'status'  => 'success',
-				'data'    => array(
-					'id' => $catalog_data['id'],
-				),
+				'id'      => $catalog_data['id'],
 				'message' => __( 'Catalog created successfully.', 'reddit-for-woocommerce' ),
 			)
 		);

--- a/includes/Admin/Export/Service/ProductExportService.php
+++ b/includes/Admin/Export/Service/ProductExportService.php
@@ -119,6 +119,11 @@ class ProductExportService {
 			Helper::with_prefix( 'batch_export_job_complete' ),
 			array( $this, 'create_feed' )
 		);
+
+		Helper::register_ajax_action(
+			'create_catalog',
+			array( $this, 'create_catalog_manually' )
+		);
 	}
 
 	/**
@@ -407,5 +412,71 @@ class ProductExportService {
 				Options::set( OptionDefaults::FEED_STATUS, 'created' );
 			}
 		}
+	}
+
+	/**
+	 * Creates a product catalog for the current business.
+	 *
+	 * This method creates a product catalog for the current business and
+	 * triggers the feed creation if the CSV export is completed and the export file URL is set.
+	 * Triggers the export if the export is not in progress and the export file URL is not set.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function create_catalog_manually() {
+		// Bail early if the catalog already exists.
+		$catalog_id = Options::get( OptionDefaults::CATALOG_ID );
+		if ( $catalog_id ) {
+			wp_send_json_error(
+				__( 'Catalog already exists.', 'reddit-for-woocommerce' )
+			);
+		}
+
+		// Create the catalog.
+		$response = $this->job->ad_partner_api->catalog->create();
+
+		if ( is_wp_error( $response ) ) {
+			$logger = wc_get_logger();
+			$logger->alert(
+				'Catalog creation failed with error code' . $response->get_error_code(),
+			);
+
+			wp_send_json_error(
+				array(
+					'message' => $response->get_error_message(),
+					'data'    => $response->get_error_data(),
+				)
+			);
+		}
+
+		$data         = $response->get_data();
+		$catalog_data = $data['data'] ?? array();
+
+		if ( ! empty( $catalog_data ) ) {
+			Options::set( OptionDefaults::CATALOG_ID, $catalog_data['id'] );
+
+			$is_job_in_progress = $this->job->is_job_in_progress( self::ACTION_HOOK );
+			$file_url           = Options::get( OptionDefaults::EXPORT_FILE_URL );
+
+			if ( ! $is_job_in_progress && ! empty( $file_url ) ) {
+				// Trigger feed creation if the export is completed.
+				$this->create_feed();
+			} elseif ( ! $is_job_in_progress && empty( $file_url ) ) {
+				// Trigger export if the export is not in progress and the export file URL is not set.
+				$this->start_export();
+			}
+		}
+
+		wp_send_json_success(
+			array(
+				'status'  => 'success',
+				'data'    => array(
+					'id' => $catalog_data['id'],
+				),
+				'message' => __( 'Catalog created successfully.', 'reddit-for-woocommerce' ),
+			)
+		);
 	}
 }

--- a/includes/Utils/Helper.php
+++ b/includes/Utils/Helper.php
@@ -60,14 +60,18 @@ class Helper {
 	 *
 	 * @since 0.1.0
 	 *
-	 * @param string   $action    Action name (will be prefixed automatically).
-	 * @param callable $callback  Callback function to handle the AJAX request.
+	 * @param string   $action     Action name (will be prefixed automatically).
+	 * @param callable $callback   Callback function to handle the AJAX request.
+	 * @param boolean  $admin_only If the action should be registered for Admin-context only.
 	 */
-	public static function register_ajax_action( string $action, callable $callback ): void {
+	public static function register_ajax_action( string $action, callable $callback, bool $admin_only = false ): void {
 		$prefixed_action = self::with_prefix( $action );
 
 		add_action( 'wp_ajax_' . $prefixed_action, $callback );
-		add_action( 'wp_ajax_nopriv_' . $prefixed_action, $callback );
+
+		if ( ! $admin_only ) {
+			add_action( 'wp_ajax_nopriv_' . $prefixed_action, $callback );
+		}
 	}
 
 	/**

--- a/js/src/data/resolvers.js
+++ b/js/src/data/resolvers.js
@@ -131,6 +131,7 @@ export function getSettings() {
 					lastExportTimeStamp: response.last_export_timestamp,
 					exportFileUrl: response.export_file_url,
 					productsToken: response.products_token,
+					catalogId: response.catalog_id,
 				} )
 			);
 		} catch ( error ) {

--- a/js/src/hooks/useCreateCatalog.js
+++ b/js/src/hooks/useCreateCatalog.js
@@ -49,7 +49,7 @@ const useCreateCatalog = () => {
 					'success',
 					__(
 						'Product catalog created successfully.',
-						'reddit-for-woo'
+						'reddit-for-woocommerce'
 					)
 				);
 			} else {
@@ -59,7 +59,7 @@ const useCreateCatalog = () => {
 						/* translators: %s is the error message */
 						__(
 							'Failed to create product catalog: %s',
-							'reddit-for-woo'
+							'reddit-for-woocommerce'
 						),
 						res.data.message
 					)
@@ -68,7 +68,7 @@ const useCreateCatalog = () => {
 		} else {
 			createNotice(
 				'error',
-				__( 'There was an error with the request.', 'reddit-for-woo' )
+				__( 'There was an error with the request.', 'reddit-for-woocommerce' )
 			);
 			setLoading( false );
 		}

--- a/js/src/hooks/useCreateCatalog.js
+++ b/js/src/hooks/useCreateCatalog.js
@@ -68,7 +68,10 @@ const useCreateCatalog = () => {
 		} else {
 			createNotice(
 				'error',
-				__( 'There was an error with the request.', 'reddit-for-woocommerce' )
+				__(
+					'There was an error with the request.',
+					'reddit-for-woocommerce'
+				)
 			);
 			setLoading( false );
 		}

--- a/js/src/hooks/useCreateCatalog.js
+++ b/js/src/hooks/useCreateCatalog.js
@@ -1,0 +1,69 @@
+/**
+ * External dependencies
+ */
+import { useCallback, useState } from '@wordpress/element';
+import { sprintf, __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { API_NAMESPACE } from '~/data/constants';
+import useApiFetchCallback from './useApiFetchCallback';
+import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
+
+/**
+ * @typedef {Object} CreateCatalog
+ * @property {Function} createCatalog Function to create a product catalog.
+ * @property {boolean} loading Indicates whether the create operation is in progress.
+ * @property {string} createdCatalogId The ID of the created product catalog.
+ */
+
+/**
+ * Create a product catalog.
+ * It creates a product catalog by calling the API.
+ *
+ * @return {CreateCatalog} An array containing the create function and a loading state.
+ *
+ * @see useApiFetchCallback
+ */
+const useCreateCatalog = () => {
+	const [ createdCatalogId, setCreatedCatalogId ] = useState( '' );
+	const { createNotice } = useDispatchCoreNotices();
+
+	const [
+		fetchCreateCatalog,
+		{ loading: loadingCreateCatalog, data: dataCreateCatalog },
+	] = useApiFetchCallback( {
+		path: `${ API_NAMESPACE }/reddit/catalog`,
+		method: 'POST',
+	} );
+
+	const createCatalog = useCallback( async () => {
+		try {
+			const { data } = await fetchCreateCatalog();
+			setCreatedCatalogId( data?.id || '' );
+			createNotice(
+				'success',
+				__( 'Product catalog created successfully.', 'reddit-for-woo' )
+			);
+		} catch ( e ) {
+			createNotice(
+				'error',
+				sprintf(
+					/* translators: %s is the error message */
+					__(
+						'Failed to create product catalog: %s',
+						'reddit-for-woo'
+					),
+					e.message
+				)
+			);
+		}
+	}, [ createNotice, fetchCreateCatalog ] );
+
+	const loading = loadingCreateCatalog || dataCreateCatalog;
+
+	return [ createCatalog, { loading, createdCatalogId } ];
+};
+
+export default useCreateCatalog;

--- a/js/src/hooks/useCreateCatalog.js
+++ b/js/src/hooks/useCreateCatalog.js
@@ -7,8 +7,6 @@ import { sprintf, __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { API_NAMESPACE } from '~/data/constants';
-import useApiFetchCallback from './useApiFetchCallback';
 import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
 
 /**
@@ -28,42 +26,55 @@ import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
  */
 const useCreateCatalog = () => {
 	const [ createdCatalogId, setCreatedCatalogId ] = useState( '' );
+	const [ loading, setLoading ] = useState( false );
 	const { createNotice } = useDispatchCoreNotices();
 
-	const [
-		fetchCreateCatalog,
-		{ loading: loadingCreateCatalog, data: dataCreateCatalog },
-	] = useApiFetchCallback( {
-		path: `${ API_NAMESPACE }/reddit/catalog`,
-		method: 'POST',
-	} );
-
 	const createCatalog = useCallback( async () => {
-		try {
-			const { data } = await fetchCreateCatalog();
-			setCreatedCatalogId( data?.id || '' );
-			createNotice(
-				'success',
-				__( 'Product catalog created successfully.', 'reddit-for-woo' )
-			);
-		} catch ( e ) {
+		setLoading( true );
+		const response = await fetch( ajaxurl, {
+			method: 'POST',
+			body: new URLSearchParams( {
+				action: `${ redditAdsAdminData.prefix }create_catalog`,
+			} ),
+		} );
+
+		if ( response.ok ) {
+			const res = await response.json();
+
+			setLoading( false );
+
+			if ( res.success ) {
+				setCreatedCatalogId( res.data.id || '' );
+				createNotice(
+					'success',
+					__(
+						'Product catalog created successfully.',
+						'reddit-for-woo'
+					)
+				);
+			} else {
+				createNotice(
+					'error',
+					sprintf(
+						/* translators: %s is the error message */
+						__(
+							'Failed to create product catalog: %s',
+							'reddit-for-woo'
+						),
+						res.data.message
+					)
+				);
+			}
+		} else {
 			createNotice(
 				'error',
-				sprintf(
-					/* translators: %s is the error message */
-					__(
-						'Failed to create product catalog: %s',
-						'reddit-for-woo'
-					),
-					e.message
-				)
+				__( 'There was an error with the request.', 'reddit-for-woo' )
 			);
+			setLoading( false );
 		}
-	}, [ createNotice, fetchCreateCatalog ] );
+	}, [ createNotice, setCreatedCatalogId, setLoading ] );
 
-	const loading = loadingCreateCatalog || dataCreateCatalog;
-
-	return [ createCatalog, { loading, createdCatalogId } ];
+	return { createCatalog, loading, createdCatalogId };
 };
 
 export default useCreateCatalog;

--- a/js/src/hooks/useSettings.js
+++ b/js/src/hooks/useSettings.js
@@ -33,6 +33,7 @@ const useSettings = () => {
 			shouldTriggerExport: settings.triggerExport,
 			lastExportTimeStamp: settings.lastExportTimeStamp,
 			exportFileUrl: settings.exportFileUrl,
+			catalogId: settings.catalogId,
 			hasFinishedResolution: selector.hasFinishedResolution(
 				selectorName,
 				[]

--- a/js/src/pages/settings/product-catalog/catalog-role-notice.js
+++ b/js/src/pages/settings/product-catalog/catalog-role-notice.js
@@ -27,7 +27,7 @@ const CatalogRoleNotice = () => {
 		hasFinishedResolution: hasFinishedResolutionRedditAccountConfig,
 	} = useRedditAccountConfig();
 
-	const [ createCatalog, { loading, createdCatalogId } ] = useCreateCatalog();
+	const { createCatalog, loading, createdCatalogId } = useCreateCatalog();
 
 	if (
 		! hasFinishedResolution ||

--- a/js/src/pages/settings/product-catalog/catalog-role-notice.js
+++ b/js/src/pages/settings/product-catalog/catalog-role-notice.js
@@ -47,28 +47,30 @@ const CatalogRoleNotice = () => {
 			isDismissible={ false }
 			className="rfw-reddit-catalog-role-notice"
 		>
-			{ __(
-				"Your account doesn't have the Catalog Manager role, which is required for catalog creation. Please assign it by going to",
-				'reddit-for-woo'
-			) }{ ' ' }
-			<strong>
+			<p>
 				{ __(
-					'Your Account › Edit › Member Details & Business Role › Advanced Role',
+					"Your account doesn't have the Catalog Manager role, which is required for catalog creation. Please assign it by going to",
+					'reddit-for-woo'
+				) }{ ' ' }
+				<strong>
+					{ __(
+						'Your Account › Edit › Member Details & Business Role › Advanced Role',
+						'reddit-for-woo'
+					) }
+				</strong>{ ' ' }
+				<Link
+					href={ rolesLink }
+					target="_blank"
+					rel="noopener noreferrer"
+					type="external"
+				>
+					{ __( 'here.', 'reddit-for-woo' ) }
+				</Link>{ ' ' }
+				{ __(
+					'Once the role is assigned, please click Create Catalog.',
 					'reddit-for-woo'
 				) }
-			</strong>{ ' ' }
-			<Link
-				href={ rolesLink }
-				target="_blank"
-				rel="noopener noreferrer"
-				type="external"
-			>
-				{ __( 'here.', 'reddit-for-woo' ) }
-			</Link>{ ' ' }
-			{ __(
-				'Once the role is assigned, please click Create Catalog.',
-				'reddit-for-woo'
-			) }
+			</p>
 			<AppButton
 				className="rfw-reddit-catalog-role-notice__create-catalog-button"
 				variant="secondary"

--- a/js/src/pages/settings/product-catalog/catalog-role-notice.js
+++ b/js/src/pages/settings/product-catalog/catalog-role-notice.js
@@ -1,0 +1,84 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Link } from '@woocommerce/components';
+
+/**
+ * Internal dependencies
+ */
+import AppNotice from '~/components/app-notice';
+import AppButton from '~/components/app-button';
+import useSettings from '~/hooks/useSettings';
+import useCreateCatalog from '~/hooks/useCreateCatalog';
+import useRedditAccountConfig from '~/hooks/useRedditAccountConfig';
+import './catalog-role-notice.scss';
+
+/**
+ * React component that displays a warning notice with link to set the catalog role and create the catalog
+ * if no catalog is created for the user.
+ *
+ * @return {JSX.Element|null} A warning notice with a link to set the catalog role and create the catalog, or null if resolution is not finished.
+ */
+const CatalogRoleNotice = () => {
+	const { catalogId, hasFinishedResolution } = useSettings();
+	const {
+		business_id: businessId,
+		hasFinishedResolution: hasFinishedResolutionRedditAccountConfig,
+	} = useRedditAccountConfig();
+
+	const [ createCatalog, { loading, createdCatalogId } ] = useCreateCatalog();
+
+	if (
+		! hasFinishedResolution ||
+		! hasFinishedResolutionRedditAccountConfig ||
+		catalogId ||
+		createdCatalogId ||
+		! businessId
+	) {
+		return null;
+	}
+
+	const rolesLink = `https://ads.reddit.com/business/${ businessId }/members`;
+
+	return (
+		<AppNotice
+			status="warning"
+			isDismissible={ false }
+			className="rfw-reddit-catalog-role-notice"
+		>
+			{ __(
+				"Your account doesn't have the Catalog Manager role, which is required for catalog creation. Please assign it by going to",
+				'reddit-for-woo'
+			) }{ ' ' }
+			<strong>
+				{ __(
+					'Your Account › Edit › Member Details & Business Role › Advanced Role',
+					'reddit-for-woo'
+				) }
+			</strong>{ ' ' }
+			<Link
+				href={ rolesLink }
+				target="_blank"
+				rel="noopener noreferrer"
+				type="external"
+			>
+				{ __( 'here.', 'reddit-for-woo' ) }
+			</Link>{ ' ' }
+			{ __(
+				'Once the role is assigned, please click Create Catalog.',
+				'reddit-for-woo'
+			) }
+			<AppButton
+				className="rfw-reddit-catalog-role-notice__create-catalog-button"
+				variant="secondary"
+				text={ __( 'Create Catalog', 'reddit-for-woo' ) }
+				isBusy={ loading }
+				isDisabled={ loading }
+				onClick={ createCatalog }
+			/>
+		</AppNotice>
+	);
+};
+
+export default CatalogRoleNotice;

--- a/js/src/pages/settings/product-catalog/catalog-role-notice.js
+++ b/js/src/pages/settings/product-catalog/catalog-role-notice.js
@@ -50,12 +50,12 @@ const CatalogRoleNotice = () => {
 			<p>
 				{ __(
 					"Your account doesn't have the Catalog Manager role, which is required for catalog creation. Please assign it by going to",
-					'reddit-for-woo'
+					'reddit-for-woocommerce'
 				) }{ ' ' }
 				<strong>
 					{ __(
 						'Your Account › Edit › Member Details & Business Role › Advanced Role',
-						'reddit-for-woo'
+						'reddit-for-woocommerce'
 					) }
 				</strong>{ ' ' }
 				<Link
@@ -64,17 +64,17 @@ const CatalogRoleNotice = () => {
 					rel="noopener noreferrer"
 					type="external"
 				>
-					{ __( 'here.', 'reddit-for-woo' ) }
+					{ __( 'here.', 'reddit-for-woocommerce' ) }
 				</Link>{ ' ' }
 				{ __(
 					'Once the role is assigned, please click Create Catalog.',
-					'reddit-for-woo'
+					'reddit-for-woocommerce'
 				) }
 			</p>
 			<AppButton
 				className="rfw-reddit-catalog-role-notice__create-catalog-button"
 				variant="secondary"
-				text={ __( 'Create Catalog', 'reddit-for-woo' ) }
+				text={ __( 'Create Catalog', 'reddit-for-woocommerce' ) }
 				isBusy={ loading }
 				isDisabled={ loading }
 				onClick={ createCatalog }

--- a/js/src/pages/settings/product-catalog/catalog-role-notice.scss
+++ b/js/src/pages/settings/product-catalog/catalog-role-notice.scss
@@ -7,8 +7,8 @@
 			margin-bottom: 0;
 		}
 
-		&__create-catalog-button {
-			margin-top: wpVariables.$grid-unit-20;
+		p {
+			margin-top: 0;
 		}
 	}
 }

--- a/js/src/pages/settings/product-catalog/catalog-role-notice.scss
+++ b/js/src/pages/settings/product-catalog/catalog-role-notice.scss
@@ -1,0 +1,14 @@
+.rfw-admin-page {
+	.rfw-reddit-catalog-role-notice {
+		margin: wpVariables.$grid-unit-20 0 0 0;
+		width: 100%;
+
+		&.components-notice {
+			margin-bottom: 0;
+		}
+
+		&__create-catalog-button {
+			margin-top: wpVariables.$grid-unit-20;
+		}
+	}
+}

--- a/js/src/pages/settings/product-catalog/index.js
+++ b/js/src/pages/settings/product-catalog/index.js
@@ -15,6 +15,7 @@ import useSettings from '~/hooks/useSettings';
 import useExportPoller from './useExportPoller';
 import useProductCatalogExport from './useProductCatalogExport';
 import './index.scss';
+import CatalogRoleNotice from './catalog-role-notice';
 
 /**
  * ProductCatalog component for managing and exporting the product catalog as a CSV file.
@@ -177,6 +178,7 @@ const ProductCatalog = () => {
 				title={ __( 'Export Product Catalog', 'reddit-for-woo' ) }
 				description={ getDescription() }
 				indicator={ getIndicator() }
+				actions={ <CatalogRoleNotice /> }
 			>
 				{ lastExported && ! fileUrl && (
 					<div className="rfw-product-catalog__help">


### PR DESCRIPTION
As reported in **REDTWOO-28**, merchants need the Catalog Manager role assigned in order to create a catalog. This PR adds a notice in the Product Catalog section with information about assigning the Catalog Manager role and a **Create Catalog** button if no catalog exists.

<img width="2135" height="745" alt="image" src="https://github.com/user-attachments/assets/41c27652-f0f9-4f11-b31d-983a470ded08" />


Closes https://linear.app/a8c/issue/REDTWOO-28/redirect-merchant-to-reddit-dashboard-to-enable-catalog-creation

### Test Steps

1. Unassign the Catalog Manager role from your account if it is already assigned.
2. Connect your Reddit account.
3. You should see a notice about creating a catalog.
4. Follow the link in the notice and assign the Catalog Manager role to your account.
5. Click **Create Catalog**.
    - ⚠️ **Please note: Catalog won't be created if a catalog already exists in the Reddit Dashboard connected to the same Pixel.**
7. Verify from the Reddit dashboard that a catalog is created with a feed.
