### PR TITLE
Add min-height to woocommerce-layout__header element.

### DIFF
--- a/js/src/css/shared/_woocommerce-admin.scss
+++ b/js/src/css/shared/_woocommerce-admin.scss
@@ -3,10 +3,6 @@
 @use "@wordpress/base-styles/breakpoints" as wpBreakpoints;
 @use "@wordpress/base-styles/variables" as wpVariables;
 
-#wpbody {
-	margin-top: 60px !important;
-}
-
 // Used in ~/hooks/useLayout.js
 .rfw-full-content {
 	.woocommerce-layout {

--- a/js/src/css/shared/_woocommerce-admin.scss
+++ b/js/src/css/shared/_woocommerce-admin.scss
@@ -85,3 +85,9 @@
 .wp-admin .woocommerce-customer-effort-score__intro {
 	margin-bottom: 1em;
 }
+
+.woocommerce-layout:has(.rfw-admin-page) {
+	.woocommerce-layout__header {
+		min-height: 60px;
+	}
+}


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/REDTWOO-40/header-settings-tabs-overlapped-by-woocommerce-layout-header