### PR TITLE
Hide number step from onboarding page.

### DIFF
--- a/js/src/pages/onboarding/setup-stepper/saved-setup-stepper.js
+++ b/js/src/pages/onboarding/setup-stepper/saved-setup-stepper.js
@@ -14,6 +14,7 @@ import { getSettingsUrl } from '~/utils/urls';
 import { STEP_NAME_KEY_MAP } from './constants';
 import { recordStepperChangeEvent } from '~/utils/tracks';
 import SetupAccounts from './setup-accounts';
+import './saved-setup-stepper.scss';
 
 /**
  * @param {Object} props React props

--- a/js/src/pages/onboarding/setup-stepper/saved-setup-stepper.scss
+++ b/js/src/pages/onboarding/setup-stepper/saved-setup-stepper.scss
@@ -1,0 +1,6 @@
+.rfw-setup-stepper {
+	// Temporarily hide the step icon/number since we have only 1 step so far.
+	.woocommerce-stepper__step-icon {
+		display: none;
+	}
+}


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/REDTWOO-36/qa-ux-can-we-hide-number-step-from-main-title-until-we-have-second

**Screenshot**
<img width="1203" height="340" alt="image" src="https://github.com/user-attachments/assets/600a8d02-b1f7-4fb3-85e7-51829272dd23" />
