### PR TITLE
REDTWOO-67: Improve Catalog creation failure error handling

### DIFF
--- a/includes/API/Site/Controllers/RedditConnectionController.php
+++ b/includes/API/Site/Controllers/RedditConnectionController.php
@@ -388,10 +388,17 @@ class RedditConnectionController extends RESTBaseController {
 			$response = $this->ad_partner_api->catalog->create();
 
 			if ( is_wp_error( $response ) ) {
-				$logger = wc_get_logger();
+				$error_data = $response->get_error_data();
+				$error_body = isset( $error_data['body'] ) ? json_decode( $error_data['body'], true ) : array();
+				$logger     = wc_get_logger();
 				$logger->alert(
 					'Catalog generation failed with error code: ' . $response->get_error_code(),
+					$error_body
 				);
+
+				if ( isset( $error_body['error']['code'] ) ) {
+					Options::set( OptionDefaults::CATALOG_STATUS, absint( $error_body['error']['code'] ) );
+				}
 			} else {
 				$data         = $response->get_data();
 				$catalog_data = $data['data'] ?? array();

--- a/includes/API/Site/Controllers/SettingsController.php
+++ b/includes/API/Site/Controllers/SettingsController.php
@@ -110,6 +110,7 @@ class SettingsController extends RESTBaseController {
 				'export_file_url'       => file_exists( $csv_path ) ? Options::get( OptionDefaults::EXPORT_FILE_URL ) : '',
 				'products_token'        => Options::get( OptionDefaults::WCS_PRODUCTS_TOKEN ),
 				'catalog_id'            => Options::get( OptionDefaults::CATALOG_ID ),
+				'catalog_status'        => (string) Options::get( OptionDefaults::CATALOG_STATUS ),
 			)
 		);
 	}

--- a/includes/CsvExporter/ProductExportService.php
+++ b/includes/CsvExporter/ProductExportService.php
@@ -452,13 +452,21 @@ class ProductExportService {
 		$response = $this->ad_partner_api->catalog->create();
 
 		if ( is_wp_error( $response ) ) {
-			$logger = wc_get_logger();
+			$error_data = $response->get_error_data();
+			$error_body = isset( $error_data['body'] ) ? json_decode( $error_data['body'], true ) : array();
+			$logger     = wc_get_logger();
 			$logger->alert(
 				'Catalog creation failed with error code' . $response->get_error_code(),
+				$error_body
 			);
+
+			if ( isset( $error_body['error']['code'] ) ) {
+				Options::set( OptionDefaults::CATALOG_STATUS, absint( $error_body['error']['code'] ) );
+			}
 
 			wp_send_json_error(
 				array(
+					'code'    => (string) $error_body['error']['code'] ?? '',
 					'message' => $response->get_error_message(),
 				)
 			);

--- a/includes/Utils/Storage/OptionDefaults.php
+++ b/includes/Utils/Storage/OptionDefaults.php
@@ -110,6 +110,11 @@ final class OptionDefaults {
 	public const CATALOG_ID = 'catalog_id';
 
 	/**
+	 * Option key indicating whether the catalog has been created.
+	 */
+	public const CATALOG_STATUS = 'catalog_status';
+
+	/**
 	 * Option key for the Ad Partner's Product Feed ID.
 	 *
 	 * @since 0.1.0
@@ -191,6 +196,7 @@ final class OptionDefaults {
 			self::PIXEL_ID              => '',
 			self::CONVERSIONS_ENABLED   => 'no',
 			self::CATALOG_ID            => '',
+			self::CATALOG_STATUS        => 'empty',
 			self::PRODUCT_FEED_ID       => '',
 			self::FEED_STATUS           => 'empty',
 			self::EXPORT_FILE_PATH      => '',

--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -191,6 +191,7 @@ export async function updateSettings( updatedSettings ) {
 
 		return receiveSettings( {
 			catalogId: response.catalog_id,
+			catalogStatus: response.catalog_status,
 			exportFileUrl: response.export_file_url,
 			lastExportTimeStamp: response.last_export_timestamp,
 			productsToken: response.products_token,

--- a/js/src/data/index.js
+++ b/js/src/data/index.js
@@ -37,6 +37,7 @@ const store = createReduxStore( STORE_KEY, {
 		trackConversions: null,
 		settings: {
 			catalogId: '',
+			catalogStatus: '',
 			exportFileUrl: '',
 			lastExportTimeStamp: '',
 			productsToken: '',

--- a/js/src/data/resolvers.js
+++ b/js/src/data/resolvers.js
@@ -126,6 +126,7 @@ export function getSettings() {
 			dispatch(
 				receiveSettings( {
 					catalogId: response.catalog_id,
+					catalogStatus: response.catalog_status,
 					exportFileUrl: response.export_file_url,
 					lastExportTimeStamp: response.last_export_timestamp,
 					productsToken: response.products_token,

--- a/js/src/hooks/useCreateCatalog.js
+++ b/js/src/hooks/useCreateCatalog.js
@@ -30,6 +30,7 @@ const { adminNonce } = rfwData;
 const useCreateCatalog = () => {
 	const [ createdCatalogId, setCreatedCatalogId ] = useState( '' );
 	const [ loading, setLoading ] = useState( false );
+	const [ errorCode, setErrorCode ] = useState( 0 );
 	const { createNotice } = useDispatchCoreNotices();
 
 	const createCatalog = useCallback( async () => {
@@ -68,6 +69,8 @@ const useCreateCatalog = () => {
 						res.data.message
 					)
 				);
+
+				setErrorCode( res.data.code );
 			}
 		} else {
 			createNotice(
@@ -81,7 +84,7 @@ const useCreateCatalog = () => {
 		}
 	}, [ createNotice, setCreatedCatalogId, setLoading ] );
 
-	return { createCatalog, loading, createdCatalogId };
+	return { createCatalog, loading, createdCatalogId, errorCode };
 };
 
 export default useCreateCatalog;

--- a/js/src/hooks/useSettings.js
+++ b/js/src/hooks/useSettings.js
@@ -33,6 +33,7 @@ const useSettings = () => {
 			lastExportTimeStamp: settings.lastExportTimeStamp,
 			exportFileUrl: settings.exportFileUrl,
 			catalogId: settings.catalogId,
+			catalogStatus: settings.catalogStatus,
 			hasFinishedResolution: selector.hasFinishedResolution(
 				selectorName,
 				[]

--- a/js/src/pages/settings/product-catalog/catalog-role-notice.js
+++ b/js/src/pages/settings/product-catalog/catalog-role-notice.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Link } from '@woocommerce/components';
+import { createInterpolateElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -21,13 +21,15 @@ import './catalog-role-notice.scss';
  * @return {JSX.Element|null} A warning notice with a link to set the catalog role and create the catalog, or null if resolution is not finished.
  */
 const CatalogRoleNotice = () => {
-	const { catalogId, hasFinishedResolution } = useSettings();
+	const { catalogId, catalogStatus, hasFinishedResolution } = useSettings();
 	const {
 		business_id: businessId,
 		hasFinishedResolution: hasFinishedResolutionRedditAccountConfig,
 	} = useRedditAccountConfig();
 
-	const { createCatalog, loading, createdCatalogId } = useCreateCatalog();
+	const { createCatalog, loading, createdCatalogId, errorCode } =
+		useCreateCatalog();
+	const catalogCreationStatus = errorCode || catalogStatus;
 
 	if (
 		! hasFinishedResolution ||
@@ -41,36 +43,61 @@ const CatalogRoleNotice = () => {
 
 	const rolesLink = `https://ads.reddit.com/business/${ businessId }/members`;
 
+	const permissionsErrorNotice = (
+		<p>
+			{ createInterpolateElement(
+				__(
+					"Your account doesn't have the Catalog Manager role, which is required for catalog creation. Please assign it by going to <strong>Your Account › Edit › Member Details & Business Role</strong> › Advanced Role <link>here</link>. Once the role is assigned, please click Create Catalog.",
+					'reddit-for-woocommerce'
+				),
+				{
+					strong: <strong />,
+					link: (
+						// eslint-disable-next-line jsx-a11y/anchor-has-content
+						<a
+							target="_blank"
+							rel="external noreferrer noopener"
+							href={ rolesLink }
+						/>
+					),
+				}
+			) }
+		</p>
+	);
+
+	const otherErrorNotice = (
+		<p>
+			{ createInterpolateElement(
+				__(
+					'There was some error creating the Catalog. Please check the <link>logs</link> for more details.',
+					'reddit-for-woocommerce'
+				),
+				{
+					link: (
+						// eslint-disable-next-line jsx-a11y/anchor-has-content
+						<a
+							target="_blank"
+							rel="external noreferrer noopener"
+							href="/wp-admin/admin.php?page=wc-status&tab=logs"
+						/>
+					),
+				}
+			) }
+		</p>
+	);
+
+	const httpErrorCode = Number( catalogCreationStatus );
+
 	return (
 		<AppNotice
 			status="warning"
 			isDismissible={ false }
 			className="rfw-reddit-catalog-role-notice"
 		>
-			<p>
-				{ __(
-					"Your account doesn't have the Catalog Manager role, which is required for catalog creation. Please assign it by going to",
-					'reddit-for-woocommerce'
-				) }{ ' ' }
-				<strong>
-					{ __(
-						'Your Account › Edit › Member Details & Business Role › Advanced Role',
-						'reddit-for-woocommerce'
-					) }
-				</strong>{ ' ' }
-				<Link
-					href={ rolesLink }
-					target="_blank"
-					rel="noopener noreferrer"
-					type="external"
-				>
-					{ __( 'here.', 'reddit-for-woocommerce' ) }
-				</Link>{ ' ' }
-				{ __(
-					'Once the role is assigned, please click Create Catalog.',
-					'reddit-for-woocommerce'
-				) }
-			</p>
+			{ httpErrorCode > 0 &&
+				httpErrorCode === 403 &&
+				permissionsErrorNotice }
+			{ httpErrorCode > 0 && httpErrorCode !== 403 && otherErrorNotice }
 			<AppButton
 				className="rfw-reddit-catalog-role-notice__create-catalog-button"
 				variant="secondary"


### PR DESCRIPTION
Closes: https://linear.app/a8c/issue/REDTWOO-67/qa-unrelated-notice-shown-during-onboarding-when-catalog-fails-due-to

Reddit REST responses don't have unique error codes, and the response messages are not user friendly such that we can directly show the messages to the merchant.

When the catalog creation fails due to lack of permissions, the response returns with HTTP 403. In this PR, we display error/notices to the merchant based on this.

- When it is 403, we show the notice instructing the error merchant to enable permissions via Reddit dashboard.
- When it is not 403 (for example, if the site is set up with an unsupported currency), we show a notice saying `There was some error creating the Catalog. Please check the <link>logs</link> for more details.`. The merchant can see the entire REST response payload in the logs.