### PR TITLE
Add PHP 8.4 tested up to header.

### DIFF
--- a/reddit-for-woocommerce.php
+++ b/reddit-for-woocommerce.php
@@ -9,6 +9,7 @@
  * Domain Path: /languages
  * Requires Plugins: woocommerce
  * Requires PHP: 7.4
+ * PHP tested up to: 8.4
  * Requires at least: 6.7
  * WC requires at least: 10.0
  * WC tested up to: 10.2


### PR DESCRIPTION
Adds the PHP tested up to header that's used in a number of other extensions to indicate the latest version the plugin is tested with. See Darin's comment https://github.com/woocommerce/woocommerce-square/pull/413#issuecomment-3398801113

Follow up to https://github.com/woocommerce/reddit-for-woocommerce/pull/41
Fixes https://linear.app/a8c/issue/REDTWOO-72/project-ensure-php-84-compatibility