### PR TITLE
REDTWOO-73: Bump WooCommerce "tested up to" version 10.3

### DIFF
--- a/reddit-for-woocommerce.php
+++ b/reddit-for-woocommerce.php
@@ -11,8 +11,8 @@
  * Requires PHP: 7.4
  * PHP tested up to: 8.4
  * Requires at least: 6.7
- * WC requires at least: 10.0
- * WC tested up to: 10.2
+ * WC requires at least: 10.1
+ * WC tested up to: 10.3
  *
  * License: GNU General Public License v3.0
  * License URI: http://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Bump WooCommerce "tested up to" version 10.3
- Bump WooCommerce minimum supported version to 10.1


Closes https://linear.app/a8c/issue/REDTWOO-73/compatibility-testing-with-woo-103-beta


### Changelog entry

> Dev - Bump WooCommerce "tested up to" version 10.3
> Dev - Bump WooCommerce minimum supported version to 10.1