### PR TITLE
REDTWOO-79: Make CAPI enabled by default.

### DIFF
--- a/includes/Utils/Storage/OptionDefaults.php
+++ b/includes/Utils/Storage/OptionDefaults.php
@@ -194,7 +194,7 @@ final class OptionDefaults {
 			self::BUSINESS_NAME         => '',
 			self::PIXEL_ENABLED         => 'yes',
 			self::PIXEL_ID              => '',
-			self::CONVERSIONS_ENABLED   => 'no',
+			self::CONVERSIONS_ENABLED   => 'yes',
 			self::CATALOG_ID            => '',
 			self::CATALOG_STATUS        => 'empty',
 			self::PRODUCT_FEED_ID       => '',

--- a/tests/e2e/global-setup.js
+++ b/tests/e2e/global-setup.js
@@ -103,11 +103,16 @@ module.exports = async ( config ) => {
 		try {
 			console.log( 'Trying to log-in as customer...' );
 			await customerPage.goto( `/wp-admin` );
-			await customerPage.fill( 'input[name="log"]', customer.username );
-			await customerPage.fill( 'input[name="pwd"]', customer.password );
-			await customerPage.locator( '#wp-submit' ).click();
 			await customerPage.waitForLoadState( 'networkidle' );
-
+			await customerPage
+				.locator( 'input[name="log"]' )
+				.fill( customer.username );
+			await customerPage.waitForTimeout( 200 );
+			await customerPage
+				.locator( 'input[name="pwd"]' )
+				.fill( customer.password );
+			await customerPage.waitForTimeout( 200 );
+			await customerPage.locator( '#wp-submit' ).click();
 			await customerPage.goto( `/my-account` );
 			await expect(
 				customerPage.locator(


### PR DESCRIPTION
PR updates the default value of the Conversions API tracking to enabled. Currently it's disabled and user has to enable it manually after complete onboarding.

Closes https://linear.app/a8c/issue/REDTWOO-79/make-capi-enabled-by-default-after-onboarding