### PR TITLE
REDTWOO-80: Add a “Reddit Ads” section to the settings.

### DIFF
--- a/js/src/pages/settings/index.js
+++ b/js/src/pages/settings/index.js
@@ -44,9 +44,7 @@ const Settings = () => {
 				<ProductCatalog />
 			</Section>
 
-			<Section
-				title={ __( 'Reddit Ads', 'reddit-for-woocommerce' ) }
-			>
+			<Section title={ __( 'Reddit Ads', 'reddit-for-woocommerce' ) }>
 				<RedditAds />
 			</Section>
 

--- a/js/src/pages/settings/index.js
+++ b/js/src/pages/settings/index.js
@@ -13,6 +13,7 @@ import LinkedAccounts from './linked-accounts';
 import Section from '~/components/section';
 import ProductCatalog from './product-catalog';
 import ConversionsAPI from './conversions-api';
+import RedditAds from './reddit-ads';
 import useRedditAccount from '~/hooks/useRedditAccount';
 import OnboardingSuccessModal from '~/components/onboarding-success-modal';
 import { getOnboardingUrl } from '~/utils/urls';
@@ -41,6 +42,12 @@ const Settings = () => {
 				title={ __( 'Product Catalog', 'reddit-for-woocommerce' ) }
 			>
 				<ProductCatalog />
+			</Section>
+
+			<Section
+				title={ __( 'Reddit Ads', 'reddit-for-woocommerce' ) }
+			>
+				<RedditAds />
 			</Section>
 
 			<Section

--- a/js/src/pages/settings/reddit-ads/index.js
+++ b/js/src/pages/settings/reddit-ads/index.js
@@ -1,0 +1,69 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import AppButton from '~/components/app-button';
+import AccountCard from '~/components/account-card';
+
+/**
+ * Clicking on the button to go to the Reddit Ads manager.
+ *
+ * @event rfw_reddit_ads_manager_button_click
+ */
+
+/**
+ * RedditAds card component for a button to go to the Reddit Ads manager.
+ *
+ * @fires rfw_reddit_ads_manager_button_click When the user clicks on the button to go to the Reddit Ads manager.
+ *
+ * @return {JSX.Element} The rendered RedditAds settings UI.
+ */
+const RedditAds = () => {
+	const getDescription = () => {
+		return __(
+			'Manage your campaigns and view performance reports.',
+			'reddit-for-woocommerce'
+		);
+	};
+
+	const getIndicator = () => {
+		const handleOnClick = () => {
+			window.open(
+				'https://ads.reddit.com/',
+				'_blank',
+				'noopener,noreferrer'
+			);
+		};
+
+		return (
+			<AppButton
+				variant="secondary"
+				onClick={ handleOnClick }
+				eventName="rfw_reddit_ads_manager_button_click"
+				eventProps={ { context: 'settings' } }
+			>
+				{ __( 'Go to my Reddit Ads Manager', 'reddit-for-woocommerce' ) }
+			</AppButton>
+		);
+	};
+
+	return (
+		<>
+			<AccountCard
+				className="rfw-reddit-ads"
+				title={ __(
+					'Reddit Ads',
+					'reddit-for-woocommerce'
+				) }
+				description={ getDescription() }
+				indicator={ getIndicator() }
+			></AccountCard>
+		</>
+	);
+};
+
+export default RedditAds;

--- a/js/src/pages/settings/reddit-ads/index.js
+++ b/js/src/pages/settings/reddit-ads/index.js
@@ -46,7 +46,10 @@ const RedditAds = () => {
 				eventName="rfw_reddit_ads_manager_button_click"
 				eventProps={ { context: 'settings' } }
 			>
-				{ __( 'Go to my Reddit Ads Manager', 'reddit-for-woocommerce' ) }
+				{ __(
+					'Go to my Reddit Ads Manager',
+					'reddit-for-woocommerce'
+				) }
 			</AppButton>
 		);
 	};
@@ -55,10 +58,7 @@ const RedditAds = () => {
 		<>
 			<AccountCard
 				className="rfw-reddit-ads"
-				title={ __(
-					'Reddit Ads',
-					'reddit-for-woocommerce'
-				) }
+				title={ __( 'Reddit Ads', 'reddit-for-woocommerce' ) }
 				description={ getDescription() }
 				indicator={ getIndicator() }
 			></AccountCard>

--- a/tests/e2e/specs/settings.spec.js
+++ b/tests/e2e/specs/settings.spec.js
@@ -142,7 +142,9 @@ test.describe( 'Reddit Settings', () => {
 		await expect( redditAccountCard ).toContainText(
 			'Pixel ID: pixel-def123'
 		);
-		await expect( redditAccountCard.locator( '.rfw-connected-icon-label' ) ).toBeVisible();
+		await expect(
+			redditAccountCard.locator( '.rfw-connected-icon-label' )
+		).toBeVisible();
 	} );
 
 	test( 'Reddit account disconnection', async () => {

--- a/tests/e2e/specs/settings.spec.js
+++ b/tests/e2e/specs/settings.spec.js
@@ -131,16 +131,18 @@ test.describe( 'Reddit Settings', () => {
 		await settingPage.mockRedditAccount( connectedConfigPayload );
 		settingPage.goto();
 
-		await expect( locator.getRedditAccountCard() ).toContainText(
+		const redditAccountCard = locator.getRedditAccountCard().last();
+
+		await expect( redditAccountCard ).toContainText(
 			'Business: R4W Business'
 		);
-		await expect( locator.getRedditAccountCard() ).toContainText(
+		await expect( redditAccountCard ).toContainText(
 			'Ads Account: R4W Ad Account (ad-account-def123)'
 		);
-		await expect( locator.getRedditAccountCard() ).toContainText(
+		await expect( redditAccountCard ).toContainText(
 			'Pixel ID: pixel-def123'
 		);
-		await expect( locator.getRedditConnectedLabel() ).toBeVisible();
+		await expect( redditAccountCard.locator( '.rfw-connected-icon-label' ) ).toBeVisible();
 	} );
 
 	test( 'Reddit account disconnection', async () => {
@@ -150,7 +152,7 @@ test.describe( 'Reddit Settings', () => {
 
 		await locator.getRedditDisconnectButton().click();
 
-		await expect( locator.getRedditAccountCard() ).toContainText(
+		await expect( locator.getRedditAccountCard().last() ).toContainText(
 			'Business: R4W Business'
 		);
 


### PR DESCRIPTION
PR adds "Reddit Ads" section to the settings to allow merchant to navigate to the Reddit Ads Manager.



<img width="1666" height="707" alt="Screenshot 2025-10-27 at 12 26 25 PM 6" src="https://github.com/user-attachments/assets/ffbda652-59f7-4f28-9f06-d43c9d4b327d" />



Closes https://linear.app/a8c/issue/REDTWOO-80/add-a-cardsection-to-the-post-onboarding-settings-view