### PR TITLE
REDTWOO-78: Update the FAQs content and add it to the settings page as well.

### DIFF
--- a/js/src/components/faqs-panel/index.scss
+++ b/js/src/components/faqs-panel/index.scss
@@ -1,10 +1,6 @@
 .rfw-faqs-panel {
 	.components-panel__row {
-		flex-direction: column;
-		gap: 1.5em;
-
-		// overrides new styles in .components-panel__row which defined align-items: center;
-		align-items: flex-start;
+		display: block;
 
 		p {
 			margin: 0;

--- a/js/src/components/paid-ads/ads-campaign/faqs.js
+++ b/js/src/components/paid-ads/ads-campaign/faqs.js
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+import { Link } from '@woocommerce/components';
 
 /**
  * Internal dependencies
@@ -10,36 +12,78 @@ import FaqsPanel from '~/components/faqs-panel';
 
 const faqItems = [
 	{
-		trackId: 'how-much-do-reddit-ads-cost',
+		trackId: 'how-should-i-set-budget-and-pacing-at-launch',
 		question: __(
-			'How much do Reddit Ads cost?',
+			'How should I set budget and pacing at launch?',
 			'reddit-for-woocommerce'
 		),
-		answer: __( 'TBD', 'reddit-for-woocommerce' ),
+		answer: __(
+			'Start with a weekly budget that can generate meaningful signal—roughly 20–30× your target CPA per ad group—so the system has enough data to learn. Fewer, well-funded ad groups beat a bunch of starved ones. Avoid major edits for the first 48–72 hours; constant changes reset learning and slow results. When you scale, do it in controlled steps (about 20–30% at a time) once performance is stable.',
+			'reddit-for-woocommerce'
+		),
 	},
 	{
-		trackId: 'what-is-the-minimum-spend-for-reddit-ads',
+		trackId: 'how-do-i-confirm-pixel-and-capi-are-working-before-i-launch',
 		question: __(
-			'What is the minimum spend for Reddit Ads?',
+			'How do I confirm Pixel and CAPI are working before I launch?',
 			'reddit-for-woocommerce'
 		),
-		answer: __( 'TBD', 'reddit-for-woocommerce' ),
+		answer: createInterpolateElement(
+			__(
+				'Open Events Manager and make sure the Pixel shows <strong>Active</strong> and Server events show <strong>Receiving</strong>. Trigger a quick test flow (view a product, add to cart, complete a test purchase) and confirm you see both client <strong>and</strong> server events within a few minutes, with the <strong>same event_id</strong> for deduplication. Check that match rates look healthy (hashed email/phone present) and that the <strong>product id in events exactly matches your feed id</strong>.',
+				'reddit-for-woocommerce'
+			),
+			{
+				strong: <strong />,
+			}
+		),
 	},
 	{
-		trackId: 'how-can-i-optimize-my-budget',
+		trackId:
+			'my-catalog-products-arent-showing-up-during-setup-what-should-i-check',
 		question: __(
-			'How can I optimize my budget?',
+			"My catalog/products aren't showing up during setup—what should I check?",
 			'reddit-for-woocommerce'
 		),
-		answer: __( 'TBD', 'reddit-for-woocommerce' ),
+		answer: __(
+			'Run a sync and review Diagnostics for missing required fields like title, price, availability, link, and image. Only in-stock items with valid images and working links will populate eligible sets. Make sure product IDs in the feed match the IDs your Pixel/CAPI send in events; mismatches break DPA targeting and reporting. Also confirm your store currency and country align with your ad account settings.',
+			'reddit-for-woocommerce'
+		),
 	},
 	{
-		trackId: 'can-i-promote-my-business-for-free-on-reddit',
+		trackId: 'what-needs-to-be-true-for-shopping-dpas-to-work-well',
 		question: __(
-			'Can I promote my business for free on Reddit?',
+			'What needs to be true for Shopping/DPAs to work well?',
 			'reddit-for-woocommerce'
 		),
-		answer: __( 'TBD', 'reddit-for-woocommerce' ),
+		answer: __(
+			'Your catalog must be healthy (no critical errors) and kept fresh with scheduled refresh so price and availability are current. Pixel + CAPI should fire purchase and view events reliably, with product IDs matching the feed exactly. Build product sets that mirror how you actually want to advertise—top sellers, new arrivals, or in-stock under a price point—so delivery stays relevant. ',
+			'reddit-for-woocommerce'
+		),
+	},
+	{
+		trackId: 'where-do-i-manage-the-campaign-after-creating-it-in-woo',
+		question: __(
+			'Where do I manage the campaign after creating it in Woo?',
+			'reddit-for-woocommerce'
+		),
+		answer: createInterpolateElement(
+			__(
+				'Manage it in <strong>Reddit Ads Manager at <adsLink>https://ads.reddit.com</adsLink>.</strong>',
+				'reddit-for-woocommerce'
+			),
+			{
+				strong: <strong />,
+				adsLink: (
+					<Link
+						href="https://ads.reddit.com/"
+						target="_blank"
+						rel="noopener noreferrer"
+						external
+					/>
+				),
+			}
+		),
 	},
 ];
 

--- a/js/src/pages/settings/index.js
+++ b/js/src/pages/settings/index.js
@@ -17,6 +17,7 @@ import useRedditAccount from '~/hooks/useRedditAccount';
 import OnboardingSuccessModal from '~/components/onboarding-success-modal';
 import { getOnboardingUrl } from '~/utils/urls';
 import './index.scss';
+import Faqs from '~/components/paid-ads/ads-campaign/faqs';
 
 const Settings = () => {
 	// Make the component highlight SFW entry in the WC legacy menu.
@@ -64,6 +65,10 @@ const Settings = () => {
 				) }
 			>
 				<LinkedAccounts />
+			</Section>
+
+			<Section>
+				<Faqs />
 			</Section>
 		</div>
 	);


### PR DESCRIPTION
PR update the FAQs content in the onboarding flow and add it to the settings page as well.

<img width="1666" height="847" alt="Screenshot 2025-10-27 at 3 50 23 PM" src="https://github.com/user-attachments/assets/bcc5c44c-8dec-4021-b502-fe5748359b96" />

Closes https://linear.app/a8c/issue/REDTWOO-78/add-faq-content