### PR TITLE
Add changelog file and fix security test issues

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,4 @@
+*** Reddit for WooCommerce Changelog ***
+
+TBD - version 0.1.0
+* Initial release

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
 			"phpcs.xml.dist",
 			"phpcs-compat.xml.dist",
 			"webpack.config.js",
-			".*"
+			".*",
+			"Tracking.md"
 		]
 	},
 	"config": {

--- a/includes/Tracking/ConversionTrackingService.php
+++ b/includes/Tracking/ConversionTrackingService.php
@@ -171,9 +171,8 @@ class ConversionTrackingService implements ServiceStatusInterface {
 	public function handle_async_add_to_cart(): void {
 		check_ajax_referer( 'capi_nonce', 'security' );
 
-		$raw_input  = filter_input( INPUT_POST, 'payload', FILTER_UNSAFE_RAW );
-		$raw_input  = wp_unslash( $raw_input );
-		$data       = json_decode( $raw_input, true );
+		$payload    = wp_unslash( $_POST['payload'] ?? '{}' ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$data       = json_decode( $payload, true );
 		$product_id = absint( $data['productId'] ?? 0 );
 		$quantity   = absint( $data['quantity'] ?? 0 );
 		$event_id   = sanitize_text_field( $data['conversionId'] ?? '' );
@@ -195,9 +194,8 @@ class ConversionTrackingService implements ServiceStatusInterface {
 	public function handle_async_view_content(): void {
 		check_ajax_referer( 'capi_nonce', 'security' );
 
-		$raw_input  = filter_input( INPUT_POST, 'payload', FILTER_UNSAFE_RAW );
-		$raw_input  = wp_unslash( $raw_input );
-		$data       = json_decode( $raw_input, true );
+		$payload    = wp_unslash( $_POST['payload'] ?? '{}' ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$data       = json_decode( $payload, true );
 		$products   = $data['products'] ?? array();
 		$product_id = absint( $products['id'] ?? 0 );
 		$event_id   = sanitize_text_field( $data['conversionId'] ?? '' );
@@ -223,10 +221,9 @@ class ConversionTrackingService implements ServiceStatusInterface {
 	public function handle_async_page_view(): void {
 		check_ajax_referer( 'capi_nonce', 'security' );
 
-		$raw_input = filter_input( INPUT_POST, 'payload', FILTER_UNSAFE_RAW );
-		$raw_input = wp_unslash( $raw_input );
-		$data      = json_decode( $raw_input, true );
-		$event_id  = sanitize_text_field( $data['conversionId'] ?? '' );
+		$payload  = wp_unslash( $_POST['payload'] ?? '{}' ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$data     = json_decode( $payload, true );
+		$event_id = sanitize_text_field( $data['conversionId'] ?? '' );
 
 		$this->tracker->track_page_view( $event_id );
 	}

--- a/includes/Utils/AssetLoader.php
+++ b/includes/Utils/AssetLoader.php
@@ -38,7 +38,8 @@ class AssetLoader {
 		$script_asset_path = $script_path . '.asset.php';
 
 		if ( file_exists( $script_asset_path ) ) {
-			$asset_data = require $script_asset_path;
+			// phpcs:ignore Squiz.Commenting.InlineComment.InvalidEndChar
+			$asset_data = require $script_asset_path; // nosemgrep
 		} else {
 			$asset_data = array(
 				'dependencies' => array(),
@@ -69,7 +70,8 @@ class AssetLoader {
 		$style_asset_path = $style_path . '.asset.php';
 
 		if ( file_exists( $style_asset_path ) ) {
-			$asset_data = require $style_asset_path;
+			// phpcs:ignore Squiz.Commenting.InlineComment.InvalidEndChar
+			$asset_data = require $style_asset_path; // nosemgrep
 		} else {
 			$asset_data = array(
 				'dependencies' => array(),


### PR DESCRIPTION
This PR includes the following changes:

* Added a new `changelog.txt` file documenting the initial release of Reddit for WooCommerce.
* Fixed the issue reported in the security test:

  * Updated AJAX handlers in `ConversionTrackingService.php` to consistently use `$_POST` for payload retrieval instead of `filter_input()`.
  * Added inline comments (`nosemgrep` and `phpcs:ignore`) to asset loading in `AssetLoader.php` to suppress false positive warnings.
* Updated `composer.json` to exclude `Tracking.md` from the build ZIP file.
