### PR TITLE
Readme updates and update “automattic/jetpack-autoloader” from 5.0.9 to 5.0.11.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
-            "version": "v5.0.9",
+            "version": "v5.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-autoloader.git",
-                "reference": "c9e9b82cc515d9ed093fa0ff21245f277aeceb4e"
+                "reference": "90bf7b3bc29cb7be74105ac99afab4c21bc47e29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/c9e9b82cc515d9ed093fa0ff21245f277aeceb4e",
-                "reference": "c9e9b82cc515d9ed093fa0ff21245f277aeceb4e",
+                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/90bf7b3bc29cb7be74105ac99afab4c21bc47e29",
+                "reference": "90bf7b3bc29cb7be74105ac99afab4c21bc47e29",
                 "shasum": ""
             },
             "require": {
@@ -25,7 +25,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^6.0.5",
+                "automattic/jetpack-changelogger": "^6.0.7",
                 "automattic/phpunit-select-config": "^1.0.3",
                 "composer/composer": "^2.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -67,9 +67,9 @@
                 "wordpress"
             ],
             "support": {
-                "source": "https://github.com/Automattic/jetpack-autoloader/tree/v5.0.9"
+                "source": "https://github.com/Automattic/jetpack-autoloader/tree/v5.0.11"
             },
-            "time": "2025-07-28T19:49:50+00:00"
+            "time": "2025-10-06T10:32:52+00:00"
         }
     ],
     "packages-dev": [

--- a/readme.txt
+++ b/readme.txt
@@ -18,12 +18,35 @@ Key features include product catalog export for Reddit's Dynamic Ads, Conversion
 
 Whether you're looking to increase brand awareness, drive sales, or re-engage existing customers, Reddit for WooCommerce provides the tools you need to create effective advertising campaigns that convert visitors into customers.
 
-== Instructions to build the plugin
+== Instructions ==
+Getting started with the Reddit for WooCommerce plugin is quick and easy! Just follow these simple steps:
+
+1. Install and activate the plugin.
+	- Once activated, go to **Marketing → Reddit** in your WordPress dashboard.
+2. Connect your WordPress.com account.
+	- On the setup screen, click **Connect** next to **WordPress.com** and sign in.
+3. Connect your Reddit Business account.
+	- Click **Connect** next to **Reddit** and follow the on-screen steps to sign in to your Reddit Business account.
+4. Complete the setup.
+	- Once both accounts are connected, click **Continue** to complete the setup process.
+5. Manage your settings.
+	- You’ll be taken to the settings page where you can turn **Conversions tracking** on or off anytime, or disconnect Reddit if needed.
+6. Verify everything is working.
+	- In your Reddit Event Manager, confirm that events are being tracked correctly.
+	- Check that your product catalog appears in your Reddit dashboard and that your products are syncing properly.
+
+== Instructions to build the plugin ==
 
 - Requires node v20 and NPM v10.
 - Requires PHP composer v2.
 - Run `npm ci && npm run build` in the plugin's root.
 - Use the generated `reddit-for-woocommerce.zip` file.
+
+== External services ==
+
+This plugin connects to a [Reddit](https://www.reddit.com) Business account to automatically sync the product catalog and track pixel and conversions events. For pixel tracking, the plugin loads the pixel script from https://www.redditstatic.com/ and sends product details, order totals, user IP address, and user agent information in the event payload if user has given consent.
+
+This service is provided by "Reddit, Inc.": [terms of use](https://redditinc.com/policies/user-agreement), [privacy policy](https://www.reddit.com/policies/privacy-policy).
 
 == FAQ ==
 


### PR DESCRIPTION
This PR makes the following changes to address feedback from the WordPress.org team:

* Updates **“automattic/jetpack-autoloader”** from 5.0.9 to 5.0.11.
* Adds setup instructions and an external services section.