### PR TITLE
Compatibility testing with WordPress 6.9

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Reddit for WooCommerce ===
 Contributors: automattic, woocommerce
 Tags: woocommerce, reddit, product feed, ads
-Tested up to: 6.8
+Tested up to: 6.9
 Stable tag: 0.1.0
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/reddit-for-woocommerce.php
+++ b/reddit-for-woocommerce.php
@@ -11,6 +11,7 @@
  * Requires PHP: 7.4
  * PHP tested up to: 8.4
  * Requires at least: 6.7
+ * Tested up to: 6.9
  * WC requires at least: 10.1
  * WC tested up to: 10.3
  *


### PR DESCRIPTION
### All Submissions:

* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

 - Bump WordPress "tested up to" version 6.9




Closes https://linear.app/a8c/issue/REDTWOO-85/compatibility-testing-with-wordpress-69-rc1


### Steps to test the changes in this Pull Request:

1. Run the e2e test using GitHub action to test this PR.
2. All tests should be passed. 
 

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Dev - Bump WordPress "tested up to" version 6.9.



