### PR TITLE
Add support for `needs: WP RC test` label to run E2E tests against WordPress RC.

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -6,6 +6,8 @@ on:
       - trunk
       - develop
   pull_request:
+    # We include `labeled` so adding the label re-triggers the workflow.
+    types: [opened, synchronize, reopened, labeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -55,6 +57,10 @@ jobs:
       - name: Install Playwright Browsers
         run: npx playwright install chromium
 
+      - name: Set WordPress RC version
+        if: "${{ contains(github.event.pull_request.labels.*.name, 'needs: WP RC test') }}"
+        run: ./tests/e2e/bin/set-core-version.js WordPress/WordPress#master
+
       - name: Setup WP environment
         run: npm run env:start
 
@@ -62,7 +68,54 @@ jobs:
         run: curl -I http://localhost:8889
 
       - name: Run E2E tests
+        id: e2e_tests
         run: npm run test:e2e
+
+      # Update label on SUCCESS (PRs only)
+      - name: Update Success Label
+        if: |
+          github.event_name == 'pull_request' &&
+          always() &&
+          steps.e2e_tests.conclusion == 'success'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        continue-on-error: true
+        with:
+          script: |
+            github.rest.issues.removeLabel({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: ['status: e2e tests failing']
+            })
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['status: e2e tests passing']
+            })
+
+      # Update label on FAILURE (PRs only)
+      - name: Update Failure Label
+        if: |
+          github.event_name == 'pull_request' &&
+          always() &&
+          steps.e2e_tests.conclusion == 'failure'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        continue-on-error: true
+        with:
+          script: |
+            github.rest.issues.removeLabel({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: ['status: e2e tests passing']
+            })
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['status: e2e tests failing']
+            })
 
       - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         if: always()

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
 				"react-dom": "^18",
 				"stylelint-config-standard-scss": "^15.0.1",
 				"typescript": "^5.5.4",
-				"woocommerce-grow-jsdoc": "https://gitpkg.now.sh/woocommerce/grow/packages/js/jsdoc?eabdb5c3e6f089499a9bc62ec2e5e2251d7b23ca"
+				"woocommerce-grow-jsdoc": "git+https://github.com/woocommerce/grow#jsdoc-v1"
 			},
 			"engines": {
 				"node": "^20",
@@ -38815,9 +38815,8 @@
 			"license": "MIT"
 		},
 		"node_modules/woocommerce-grow-jsdoc": {
-			"version": "0.0.2",
-			"resolved": "https://gitpkg.now.sh/woocommerce/grow/packages/js/jsdoc?eabdb5c3e6f089499a9bc62ec2e5e2251d7b23ca",
-			"integrity": "sha512-r8yvGjSD7DSEfg6OsuEFnjIcsR8kZ8NRWclNAbTssgnSoZzwRU0hzGnGTHHa3wfrK5M8KjPtZvmZfofQbCQPqw==",
+			"version": "1.0.0",
+			"resolved": "git+ssh://git@github.com/woocommerce/grow.git#d1822ab1ad130d28d096845798200782e3a8f59d",
 			"dev": true,
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
@@ -38826,18 +38825,23 @@
 				"jsdoc-plugin-intersection": "^1.0.4",
 				"jsdoc-plugin-typescript": "^2.2.1",
 				"shelljs": "^0.8.5",
-				"woocommerce-grow-tracking-jsdoc": "https://gitpkg.now.sh/woocommerce/grow/packages/js/tracking-jsdoc?a22d3df5e1b121ab186c57fa4fb9bbc989c86fba"
+				"woocommerce-grow-tracking-jsdoc": "git+https://github.com/woocommerce/grow#tracking-jsdoc-v1"
 			},
 			"bin": {
 				"woocommerce-grow-jsdoc": "bin/jsdoc.mjs"
+			},
+			"engines": {
+				"node": ">=16"
 			}
 		},
 		"node_modules/woocommerce-grow-tracking-jsdoc": {
-			"version": "0.0.2",
-			"resolved": "https://gitpkg.now.sh/woocommerce/grow/packages/js/tracking-jsdoc?a22d3df5e1b121ab186c57fa4fb9bbc989c86fba",
-			"integrity": "sha512-RMZecq3RbgutjnmAbrO0dLBQ/MX3i/kQXyHGeYITocOIDZIabUX6mvEEK2uHu2frtvAVn154u3upEMk7X8JZnw==",
+			"version": "1.0.0",
+			"resolved": "git+ssh://git@github.com/woocommerce/grow.git#ac115c64c5427ae6b2a9d9ccd0498e82a1864a8e",
 			"dev": true,
 			"license": "GPL-3.0-or-later",
+			"engines": {
+				"node": ">=16"
+			},
 			"peerDependencies": {
 				"jsdoc": "^4.0.2"
 			}

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
 		"react-dom": "^18",
 		"stylelint-config-standard-scss": "^15.0.1",
 		"typescript": "^5.5.4",
-		"woocommerce-grow-jsdoc": "https://gitpkg.now.sh/woocommerce/grow/packages/js/jsdoc?eabdb5c3e6f089499a9bc62ec2e5e2251d7b23ca"
+		"woocommerce-grow-jsdoc": "git+https://github.com/woocommerce/grow#jsdoc-v1"
 	},
 	"overrides": {
 		"@woocommerce/eslint-plugin": {

--- a/tests/e2e/bin/set-core-version.js
+++ b/tests/e2e/bin/set-core-version.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+const fs = require( 'fs' );
+const { exit } = require( 'process' );
+
+const path = `${ process.cwd() }/.wp-env.override.json`;
+
+// eslint-disable-next-line import/no-dynamic-require
+const config = fs.existsSync( path ) ? require( path ) : {};
+
+const args = process.argv.slice( 2 );
+
+if ( args.length === 0 ) {
+	exit( 0 );
+}
+
+if ( args[ 0 ] === 'latest' ) {
+	if ( fs.existsSync( path ) ) {
+		fs.unlinkSync( path );
+	}
+	exit( 0 );
+}
+
+config.core = args[ 0 ];
+
+// eslint-disable-next-line no-useless-escape
+if ( ! config.core.match( /^WordPress\/WordPress\#/ ) ) {
+	config.core = `WordPress/WordPress#${ config.core }`;
+}
+
+try {
+	fs.writeFileSync( path, JSON.stringify( config ) );
+} catch ( err ) {
+	// eslint-disable-next-line no-console
+	console.error( err );
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:
PR adds support for the `needs: WP RC test` label to run E2E tests against the WordPress RC version. This label is mainly useful when we want to run E2E tests against the WordPress RC version for compatibility testing of the upcoming WordPress release.

### Steps to test the changes in this Pull Request:
1. Apply label `needs: WP RC test` to PR
2. Make sure E2E test workflow run successfully and success label added to PR.

### Changelog entry
> Dev - Add support for `needs: WP RC test` label to run E2E tests against WordPress RC.