### PR TITLE
REDTWOO-91: Update average daily budget suggestions

### DIFF
--- a/includes/API/Site/Controllers/CampaignController.php
+++ b/includes/API/Site/Controllers/CampaignController.php
@@ -275,7 +275,7 @@ class CampaignController extends RESTBaseController {
 	 *
 	 * @param string $campaign_id    Campaign ID.
 	 * @param string $product_set_id Product set ID.
-	 * @param string $daily_budget   Daily budget.
+	 * @param float  $daily_budget   Daily budget.
 	 *
 	 * @return array|WP_Error Ad group IDs or WP_Error if something went wrong.
 	 */

--- a/includes/API/Site/Controllers/CampaignController.php
+++ b/includes/API/Site/Controllers/CampaignController.php
@@ -373,12 +373,6 @@ class CampaignController extends RESTBaseController {
 		}
 
 		$amount = floatval( wp_unslash( $amount ) );
-		if ( $amount <= 0 ) {
-			return new WP_Error(
-				'invalid_amount',
-				__( 'Amount must be greater than 0.', 'reddit-for-woocommerce' )
-			);
-		}
 
 		if ( $amount < 10 ) {
 			return new WP_Error(

--- a/includes/API/Site/Controllers/CampaignController.php
+++ b/includes/API/Site/Controllers/CampaignController.php
@@ -258,10 +258,18 @@ class CampaignController extends RESTBaseController {
 	 *
 	 * Creates ad groups for the campaign to set the daily budget and targeting type.
 	 *
-	 * 2 Ad Groups are created with different targeting types and budgets (70% and 30% budget):
-	 * - Prospecting (70% budget)
-	 * - Retargeting (30% budget)
+	 * 2 Ad Groups are created with different targeting types and budgets:
+	 * - Prospecting
+	 * - Retargeting
 	 *   - Retarget people with previous events: add to cart + view content
+	 *
+	 * If a user enters a custom daily budget less than $17:
+	 * - Prospecting: 50% budget
+	 * - Retargeting: 50% budget
+	 *
+	 * If a user enters a custom daily budget greater than or equal to $17:
+	 * - Prospecting: 70% budget
+	 * - Retargeting: 30% budget
 	 *
 	 * @since 0.1.0
 	 *
@@ -275,9 +283,14 @@ class CampaignController extends RESTBaseController {
 		$ad_group_ids = array();
 
 		$targeting_types = array(
-			'PROSPECTING' => 0.70,
-			'RETARGETING' => 0.30,
+			'PROSPECTING' => 0.50,
+			'RETARGETING' => 0.50,
 		);
+
+		if ( $daily_budget >= 17 ) {
+			$targeting_types['PROSPECTING'] = 0.70;
+			$targeting_types['RETARGETING'] = 0.30;
+		}
 
 		foreach ( $targeting_types as $targeting_type => $budget_percentage ) {
 			$ad_group_data = array(
@@ -365,6 +378,14 @@ class CampaignController extends RESTBaseController {
 				__( 'Amount must be greater than 0.', 'reddit-for-woocommerce' )
 			);
 		}
+
+		if ( $amount < 10 ) {
+			return new WP_Error(
+				'invalid_daily_budget',
+				__( 'Daily budget must be greater than 10.', 'reddit-for-woocommerce' )
+			);
+		}
+
 		return true;
 	}
 

--- a/includes/API/Site/Controllers/CampaignController.php
+++ b/includes/API/Site/Controllers/CampaignController.php
@@ -283,13 +283,14 @@ class CampaignController extends RESTBaseController {
 		$ad_group_ids = array();
 
 		$targeting_types = array(
-			'PROSPECTING' => 0.50,
-			'RETARGETING' => 0.50,
+			'PROSPECTING' => 0.70,
+			'RETARGETING' => 0.30,
 		);
 
-		if ( $daily_budget >= 17 ) {
-			$targeting_types['PROSPECTING'] = 0.70;
-			$targeting_types['RETARGETING'] = 0.30;
+		// If the daily budget is less than $17, set the budget to 50% for both targeting types.
+		if ( $daily_budget < 17 ) {
+			$targeting_types['PROSPECTING'] = 0.50;
+			$targeting_types['RETARGETING'] = 0.50;
 		}
 
 		foreach ( $targeting_types as $targeting_type => $budget_percentage ) {

--- a/js/src/components/paid-ads/campaign-assets-form.js
+++ b/js/src/components/paid-ads/campaign-assets-form.js
@@ -70,9 +70,9 @@ export default function CampaignAssetsForm( {
 } ) {
 	const { formatAmount } = useAdsCurrency();
 	const budgetRecommendation = {
-		dailyBudgetBaseline: 16.67, // This is the minimum daily budget required by Reddit for the 70/30 split.
+		dailyBudgetBaseline: 10,
 		recommended: {
-			dailyBudget: 63.3,
+			dailyBudget: 65,
 			metrics: {
 				cost: 443.1,
 				conversions: 13.1,
@@ -82,7 +82,7 @@ export default function CampaignAssetsForm( {
 			currency: 'USD',
 		},
 		high: {
-			dailyBudget: 75.96,
+			dailyBudget: 85,
 			metrics: {
 				cost: 531.72,
 				conversions: 13.5,
@@ -92,7 +92,7 @@ export default function CampaignAssetsForm( {
 			currency: 'USD',
 		},
 		low: {
-			dailyBudget: 50.64,
+			dailyBudget: 45,
 			metrics: {
 				cost: 354.48,
 				conversions: 12,
@@ -101,10 +101,10 @@ export default function CampaignAssetsForm( {
 			country: 'US',
 			currency: 'USD',
 		},
-		recommendedDailyBudget: 63.3,
+		recommendedDailyBudget: 65,
 		eventProps: {
 			source: 'reddit-ads-api',
-			recommended_budget: 63.3,
+			recommended_budget: 65,
 			metrics_availability: 'all',
 		},
 	};


### PR DESCRIPTION
### Changes proposed in this Pull Request:
PR makes following changes:
1. Set minimum custom daily budget: $10.
<img width="895" height="191" alt="image" src="https://github.com/user-attachments/assets/879befdf-f599-428f-a014-4dffd42420f6" />

2. Update preset daily budget tiers to: $85, $65 (recommended) and $45
<img width="895" height="647" alt="image" src="https://github.com/user-attachments/assets/06c86a6f-94c7-4df1-937a-7d918110e3b7" />

3. Update budget split between ad groups based on budget value:
- If a user enters a custom daily budget less than $17: Apply 50/50 split between Prospecting and Retargeting.
- If a user enters a custom daily budget greater than or equal to $17: Apply 70/30 split between Prospecting and Retargeting.

> [!WARNING]
> These budget tiers are hardcoded and remain the same regardless of the ad account currency. For example, if the ad account currency is EUR, the daily budget tiers will be €85, €65 (recommended), and €45. The same applies to the minimum daily budget requirement as well.

Closes https://linear.app/a8c/issue/REDTWOO-91/prd-update-reddit-for-woo-average-daily-budget-suggestions

### Steps to test the changes in this Pull Request:
1. Install plugin.
2. Connect Reddit account and verify following things in create campaign step in onboarding:
- In the "Average daily budget" UI, the preset daily budget tiers must be:
    - $85
    - $65 (recommended)
    - $45
    - Set custom budget
- Minimum budget requirement is $10.00
- If a user enters a custom daily budget less than $17:
    - The system must enforce a 50/50 split between Prospecting and Retargeting.
- If a user enters a custom daily budget greater than or equal to $17:
    - The system may apply the existing/default split behavior (e.g. 70/30)
 

### Changelog entry
> Update - Average daily budget suggestions and minimum budget requirements.