### PR TITLE
Add the deploy GH workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,76 @@
+name: Deploy Plugin
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to deploy (e.g., 1.0.0)'
+        required: true
+        type: string
+      deploy_wporg:
+        description: 'Deploy to WordPress.org'
+        required: false
+        default: true
+        type: boolean
+      deploy_github:
+        description: 'Deploy to GitHub'
+        required: false
+        default: true
+        type: boolean
+      simulate:
+        description: 'Dry run mode'
+        required: false
+        default: true
+        type: boolean
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout the private action repository
+      - name: Checkout woo-product-deploy action
+        uses: actions/checkout@v4
+        with:
+          repository: woocommerce/woo-product-deploy
+          ref: trunk
+          path: ./.github/actions/woo-product-deploy
+          token: ${{ secrets.ORG_DEPLOY_SECRET }}  # Need PAT with access to the action repository
+
+      # Use the action we checked out
+      - name: Deploy Product
+        uses: ./.github/actions/woo-product-deploy
+        with:
+          repo_url: https://github.com/woocommerce/reddit-for-woocommerce
+          branch: ${{ github.ref_name }}
+          version: ${{ github.event.inputs.version }}
+          node_version: '20'
+          npm_version: '10'
+          simulate: ${{ github.event.inputs.simulate }}
+          github_release: ${{ github.event.inputs.deploy_github }}
+          wporg_release: ${{ github.event.inputs.deploy_wporg }}
+          wporg_username: ${{ secrets.WPORG_USERNAME }}
+          wporg_password: ${{ secrets.WPORG_PASSWORD }}
+          deploy_pat: ${{ secrets.ORG_DEPLOY_SECRET }}
+          partner_user: ${{ secrets.ORG_PARTNER_USER }}
+          partner_secret: ${{ secrets.ORG_PARTNER_DEPLOY_SECRET }}
+
+      - name: Copy build zip and preview changes
+        run: |
+          TEMP_DIR=$(php -r 'echo sys_get_temp_dir();')
+          SIMULATE=${{ github.event.inputs.simulate }}
+
+          cd "$TEMP_DIR/reddit-for-woocommerce"
+          cp reddit-for-woocommerce.zip ${{ github.workspace }}
+
+          # Show git diff if it's a dry run
+          if [ "$SIMULATE" == "true" ]; then
+            git --no-pager diff
+          fi
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: reddit-for-woocommerce.zip
+          path: ${{ github.workspace }}/reddit-for-woocommerce.zip
+          retention-days: 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       # Checkout the private action repository
       - name: Checkout woo-product-deploy action
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # 4.3.0
         with:
           repository: woocommerce/woo-product-deploy
           ref: trunk


### PR DESCRIPTION
> [!warning]
> Before this action will work for .org deploys, we will need the `WPORG_USERNAME` and `WPORG_PASSWORD` secrets to be added to the repo.

Fixes REDTWOO-90.

This adds a deploy workflow that uses the woo-product-deploy action.

The action can deploy plugin versions directly from `trunk` or from a release branch generated by the prepare-release workflow.

## Testing

Once merged, deploys can be tested using the "Simulate" mode to run the deploy action without actually publishing. This will result in a zip file uploaded to the action summary that can be used for smoke testing before running the real deployment.

