### PR TITLE
REDTWOO-95: UX improvements for the Reddit Ads card.

### DIFF
--- a/includes/API/Site/Controllers/CampaignController.php
+++ b/includes/API/Site/Controllers/CampaignController.php
@@ -99,13 +99,13 @@ class CampaignController extends RESTBaseController {
 		$ad_account_id = Options::get( OptionDefaults::AD_ACCOUNT_ID );
 
 		// Create a new campaign. If the campaign creation fails, return an error.
-		$campaign = $this->create_campaign();
+		$campaign_id = $this->create_campaign();
 
-		if ( is_wp_error( $campaign ) ) {
+		if ( is_wp_error( $campaign_id ) ) {
 			return new WP_REST_Response(
 				array(
 					'status'  => 'error',
-					'message' => $campaign->get_error_message(),
+					'message' => $campaign_id->get_error_message(),
 				),
 				500
 			);
@@ -125,7 +125,7 @@ class CampaignController extends RESTBaseController {
 		}
 
 		// Create ad groups for the campaign to set the daily budget and targeting type.
-		$ad_group_ids = $this->create_ad_groups( $campaign, $product_set_id, $amount );
+		$ad_group_ids = $this->create_ad_groups( $campaign_id, $product_set_id, $amount );
 
 		if ( is_wp_error( $ad_group_ids ) ) {
 			return new WP_REST_Response(
@@ -152,6 +152,11 @@ class CampaignController extends RESTBaseController {
 
 		// Delete the transients.
 		Transients::delete( sprintf( '%s_%s', TransientDefaults::PRODUCT_SET_ID, $ad_account_id ) );
+
+		// Set created campaign ID to the options, to archive it while disconnect account.
+		$campaign_ids   = Options::get( OptionDefaults::CAMPAIGN_IDS );
+		$campaign_ids[] = $campaign_id;
+		Options::set( OptionDefaults::CAMPAIGN_IDS, $campaign_ids );
 
 		return rest_ensure_response(
 			array(

--- a/includes/API/Site/Controllers/OnboardingController.php
+++ b/includes/API/Site/Controllers/OnboardingController.php
@@ -61,10 +61,6 @@ class OnboardingController extends RESTBaseController {
 		$status = Options::get( OptionDefaults::ONBOARDING_STATUS );
 		$step   = Options::get( OptionDefaults::ONBOARDING_STEP );
 
-		if ( 'connected' === $status ) {
-			$step = 'paid_ads';
-		}
-
 		return rest_ensure_response(
 			array(
 				'status' => $status,

--- a/includes/API/Site/Controllers/OnboardingController.php
+++ b/includes/API/Site/Controllers/OnboardingController.php
@@ -58,10 +58,17 @@ class OnboardingController extends RESTBaseController {
 	 * @return WP_REST_Response
 	 */
 	public function get_setup_state(): WP_REST_Response {
+		$status = Options::get( OptionDefaults::ONBOARDING_STATUS );
+		$step   = Options::get( OptionDefaults::ONBOARDING_STEP );
+
+		if ( 'connected' === $status ) {
+			$step = 'paid_ads';
+		}
+
 		return rest_ensure_response(
 			array(
-				'status' => Options::get( OptionDefaults::ONBOARDING_STATUS ),
-				'step'   => Options::get( OptionDefaults::ONBOARDING_STEP ),
+				'status' => $status,
+				'step'   => $step,
 			)
 		);
 	}

--- a/includes/API/Site/Controllers/RedditConnectionController.php
+++ b/includes/API/Site/Controllers/RedditConnectionController.php
@@ -331,6 +331,7 @@ class RedditConnectionController extends RESTBaseController {
 		Options::delete( OptionDefaults::PIXEL_ID );
 		Options::delete( OptionDefaults::IS_JETPACK_CONNECTED );
 		Options::delete( OptionDefaults::ONBOARDING_STATUS );
+		Options::delete( OptionDefaults::ONBOARDING_STEP );
 		Options::delete( OptionDefaults::LAST_EXPORT_TIMESTAMP );
 		Options::delete( OptionDefaults::EXPORT_FILE_PATH );
 		Options::delete( OptionDefaults::EXPORT_FILE_URL );
@@ -413,6 +414,7 @@ class RedditConnectionController extends RESTBaseController {
 			do_action( Helper::with_prefix( 'before_onboarding_complete' ) );
 
 			Options::set( OptionDefaults::ONBOARDING_STATUS, 'connected' );
+			Options::set( OptionDefaults::ONBOARDING_STEP, 'paid_ads' );
 
 			// Set the profile ID.
 			$member = $this->ad_partner_api->members->me();

--- a/includes/API/Site/Controllers/RedditConnectionController.php
+++ b/includes/API/Site/Controllers/RedditConnectionController.php
@@ -341,6 +341,7 @@ class RedditConnectionController extends RESTBaseController {
 		Options::delete( OptionDefaults::PROFILE_ID );
 		Options::delete( OptionDefaults::DUMMY_PURCHASE_TRACKED );
 		Options::delete( OptionDefaults::ADS_ACCOUNT_CURRENCY );
+		Options::delete( OptionDefaults::CAMPAIGN_IDS );
 		Transients::delete( TransientDefaults::REDDIT_ACCOUNT_EMAIL );
 		Transients::delete( TransientDefaults::PIXEL_SCRIPT );
 		Transients::delete( sprintf( '%s_%s', TransientDefaults::PRODUCT_SET_ID, $ad_account_id ) );

--- a/includes/API/Site/Controllers/SettingsController.php
+++ b/includes/API/Site/Controllers/SettingsController.php
@@ -99,8 +99,9 @@ class SettingsController extends RESTBaseController {
 	 * @return WP_REST_Response
 	 */
 	private function get_settings_response() {
-		$timestamp = Options::get( OptionDefaults::LAST_EXPORT_TIMESTAMP );
-		$csv_path  = Options::get( OptionDefaults::EXPORT_FILE_PATH );
+		$timestamp        = Options::get( OptionDefaults::LAST_EXPORT_TIMESTAMP );
+		$csv_path         = Options::get( OptionDefaults::EXPORT_FILE_PATH );
+		$campaign_created = ! empty( Options::get( OptionDefaults::CAMPAIGN_IDS ) );
 
 		return rest_ensure_response(
 			array(
@@ -111,6 +112,7 @@ class SettingsController extends RESTBaseController {
 				'products_token'        => Options::get( OptionDefaults::WCS_PRODUCTS_TOKEN ),
 				'catalog_id'            => Options::get( OptionDefaults::CATALOG_ID ),
 				'catalog_status'        => (string) Options::get( OptionDefaults::CATALOG_STATUS ),
+				'campaign_created'      => $campaign_created,
 			)
 		);
 	}

--- a/includes/Utils/Storage/OptionDefaults.php
+++ b/includes/Utils/Storage/OptionDefaults.php
@@ -195,6 +195,13 @@ final class OptionDefaults {
 	public const ADS_ACCOUNT_CURRENCY = 'ad_account_currency';
 
 	/**
+	 * Option key to store the Ad Partner's Campaign IDs.
+	 *
+	 * @since 0.1.0
+	 */
+	public const CAMPAIGN_IDS = 'campaign_ids';
+
+	/**
 	 * Returns default values for all known Ad Partner options.
 	 *
 	 * Used by {@see Options} to provide fallbacks when option values
@@ -228,6 +235,7 @@ final class OptionDefaults {
 			self::PROFILE_ID             => '',
 			self::DUMMY_PURCHASE_TRACKED => 'no',
 			self::ADS_ACCOUNT_CURRENCY   => get_woocommerce_currency(),
+			self::CAMPAIGN_IDS           => array(),
 		);
 	}
 }

--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -197,6 +197,7 @@ export async function updateSettings( updatedSettings ) {
 			lastExportTimeStamp: response.last_export_timestamp,
 			productsToken: response.products_token,
 			trackConversions: Boolean( response.capi_enabled ),
+			campaignCreated: Boolean( response.campaign_created ),
 			triggerExport: Boolean( response.trigger_export ),
 		} );
 	} catch ( error ) {

--- a/js/src/data/index.js
+++ b/js/src/data/index.js
@@ -43,6 +43,7 @@ const store = createReduxStore( STORE_KEY, {
 			exportFileUrl: '',
 			lastExportTimeStamp: '',
 			productsToken: '',
+			campaignCreated: false,
 			trackConversions: false,
 			triggerExport: false,
 		},

--- a/js/src/data/resolvers.js
+++ b/js/src/data/resolvers.js
@@ -131,6 +131,7 @@ export function getSettings() {
 					lastExportTimeStamp: response.last_export_timestamp,
 					productsToken: response.products_token,
 					trackConversions: Boolean( response.capi_enabled ),
+					campaignCreated: Boolean( response.campaign_created ),
 					triggerExport: Boolean( response.trigger_export ),
 				} )
 			);

--- a/js/src/hooks/useSettings.js
+++ b/js/src/hooks/useSettings.js
@@ -29,6 +29,7 @@ const useSettings = () => {
 		return {
 			productsToken: settings.productsToken,
 			isCapiEnabled: settings.trackConversions,
+			isCampaignCreated: settings.campaignCreated,
 			shouldTriggerExport: settings.triggerExport,
 			lastExportTimeStamp: settings.lastExportTimeStamp,
 			exportFileUrl: settings.exportFileUrl,

--- a/js/src/pages/settings/index.scss
+++ b/js/src/pages/settings/index.scss
@@ -12,6 +12,11 @@
 			max-width: 328px;
 			padding-top: var(--large-gap);
 		}
+
+		.rfw-reddit-ads-buttons {
+			display: flex;
+			gap: wpVariables.$grid-unit-10;
+		}
 	}
 
 	.rfw-subsection-helper-text {

--- a/js/src/pages/settings/reddit-ads/index.js
+++ b/js/src/pages/settings/reddit-ads/index.js
@@ -6,32 +6,59 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import useAdminUrl from '~/hooks/useAdminUrl';
+import { getOnboardingUrl } from '~/utils/urls';
+import useSettings from '~/hooks/useSettings';
 import AppButton from '~/components/app-button';
 import AccountCard from '~/components/account-card';
+import SpinnerCard from '~/components/spinner-card';
 
 /**
- * Clicking on the button to go to the Reddit Ads manager.
+ * Clicking on the button to create a campaign on the Reddit Ads manager.
  *
- * @event rfw_reddit_ads_manager_button_click
+ * @event rfw_reddit_ads_create_campaign_on_reddit_button_click
+ */
+
+/**
+ * Clicking on the button to create a campaign from the Onboarding flow.
+ *
+ * @event rfw_reddit_ads_create_campaign_button_click
+ */
+
+/**
+ * Clicking on the button to go to the Reddit Ads dashboard.
+ *
+ * @event rfw_reddit_go_to_dashboard_button_click
  */
 
 /**
  * RedditAds card component for a button to go to the Reddit Ads manager.
  *
- * @fires rfw_reddit_ads_manager_button_click When the user clicks on the button to go to the Reddit Ads manager.
+ * @fires rfw_reddit_ads_create_campaign_on_reddit_button_click When the user clicks on the button to create a campaign on the Reddit Ads manager.
+ * @fires rfw_reddit_ads_create_campaign_button_click When the user clicks on the button to create a campaign from the Onboarding flow.
+ * @fires rfw_reddit_go_to_dashboard_button_click When the user clicks on the button to go to the Reddit Ads dashboard.
  *
  * @return {JSX.Element} The rendered RedditAds settings UI.
  */
 const RedditAds = () => {
+	const { isCampaignCreated, hasFinishedResolution } = useSettings();
+	const adminUrl = useAdminUrl();
 	const getDescription = () => {
-		return __(
-			'Manage your campaigns and view performance reports.',
-			'reddit-for-woocommerce'
-		);
+		return isCampaignCreated ? __(
+				'Manage your campaigns and view performance reports.',
+				'reddit-for-woocommerce'
+			) : __(
+				'Create a Reddit campaign to promote your products.',
+				'reddit-for-woocommerce'
+			);
 	};
 
 	const getIndicator = () => {
-		const handleOnClick = () => {
+		const handleCreateCampaignButtonClick = () => {
+			window.location.href = adminUrl + getOnboardingUrl();
+		};
+
+		const handleCreateCampaignOnRedditButtonClick = () => {
 			window.open(
 				'https://ads.reddit.com/create?flow=advanced&objective=catalogSales&utm_source=partnership&utm_name=woo_commerce',
 				'_blank',
@@ -39,20 +66,61 @@ const RedditAds = () => {
 			);
 		};
 
+		const handleGoToDashboardButtonClick = () => {
+			window.open(
+				'https://ads.reddit.com/dashboard?utm_source=partnership&utm_name=woo_commerce',
+				'_blank',
+				'noopener,noreferrer'
+			);
+		};
+
+		if ( ! isCampaignCreated ) {
+			return (
+				<AppButton
+					variant="secondary"
+					onClick={ handleCreateCampaignButtonClick }
+					eventName="rfw_reddit_ads_create_campaign_button_click"
+					eventProps={ { context: 'settings' } }
+				>
+					{ __(
+						'Create Campaign',
+						'reddit-for-woocommerce'
+					) }
+				</AppButton>
+			);
+		}
+
 		return (
-			<AppButton
-				variant="secondary"
-				onClick={ handleOnClick }
-				eventName="rfw_reddit_ads_manager_button_click"
-				eventProps={ { context: 'settings' } }
-			>
-				{ __(
-					'Go to my Reddit Ads Manager',
-					'reddit-for-woocommerce'
-				) }
-			</AppButton>
+			<div className="rfw-reddit-ads-buttons">
+				<AppButton
+					variant="secondary"
+					onClick={ handleCreateCampaignOnRedditButtonClick }
+					eventName="rfw_reddit_ads_create_campaign_on_reddit_button_click"
+					eventProps={ { context: 'settings' } }
+				>
+					{ __(
+						'Create Campaign',
+						'reddit-for-woocommerce'
+					) }
+				</AppButton>
+				<AppButton
+					variant="secondary"
+					onClick={ handleGoToDashboardButtonClick }
+					eventName="rfw_reddit_go_to_dashboard_button_click"
+					eventProps={ { context: 'settings' } }
+				>
+					{ __(
+						'Go to Dashboard',
+						'reddit-for-woocommerce'
+					) }
+				</AppButton>
+			</div>
 		);
 	};
+
+	if ( ! hasFinishedResolution ) {
+		return <SpinnerCard />;
+	}
 
 	return (
 		<>

--- a/js/src/pages/settings/reddit-ads/index.js
+++ b/js/src/pages/settings/reddit-ads/index.js
@@ -44,13 +44,15 @@ const RedditAds = () => {
 	const { isCampaignCreated, hasFinishedResolution } = useSettings();
 	const adminUrl = useAdminUrl();
 	const getDescription = () => {
-		return isCampaignCreated ? __(
-				'Manage your campaigns and view performance reports.',
-				'reddit-for-woocommerce'
-			) : __(
-				'Create a Reddit campaign to promote your products.',
-				'reddit-for-woocommerce'
-			);
+		return isCampaignCreated
+			? __(
+					'Manage your campaigns and view performance reports.',
+					'reddit-for-woocommerce'
+			  )
+			: __(
+					'Create a Reddit campaign to promote your products.',
+					'reddit-for-woocommerce'
+			  );
 	};
 
 	const getIndicator = () => {
@@ -82,10 +84,7 @@ const RedditAds = () => {
 					eventName="rfw_reddit_ads_create_campaign_button_click"
 					eventProps={ { context: 'settings' } }
 				>
-					{ __(
-						'Create Campaign',
-						'reddit-for-woocommerce'
-					) }
+					{ __( 'Create Campaign', 'reddit-for-woocommerce' ) }
 				</AppButton>
 			);
 		}
@@ -98,10 +97,7 @@ const RedditAds = () => {
 					eventName="rfw_reddit_ads_create_campaign_on_reddit_button_click"
 					eventProps={ { context: 'settings' } }
 				>
-					{ __(
-						'Create Campaign',
-						'reddit-for-woocommerce'
-					) }
+					{ __( 'Create Campaign', 'reddit-for-woocommerce' ) }
 				</AppButton>
 				<AppButton
 					variant="secondary"
@@ -109,10 +105,7 @@ const RedditAds = () => {
 					eventName="rfw_reddit_go_to_dashboard_button_click"
 					eventProps={ { context: 'settings' } }
 				>
-					{ __(
-						'Go to Dashboard',
-						'reddit-for-woocommerce'
-					) }
+					{ __( 'Go to Dashboard', 'reddit-for-woocommerce' ) }
 				</AppButton>
 			</div>
 		);


### PR DESCRIPTION
### Changes proposed in this Pull Request:
As requested in REDTWOO-95, this PR updates the Reddit Ads card to allow re-attempting campaign creation. Once the campaign is created, it displays two buttons: one to go to the Reddit dashboard and another to create a new campaign on the Reddit side.

| Before Campaign created (skipped in onboarding) | After campaign is created |
|---|---|
|<img width="1998" height="463" alt="Screenshot 2025-12-24 at 7 01 24 PM" src="https://github.com/user-attachments/assets/8d60926f-0bef-4372-b994-f995c3069e89" />|<img width="1998" height="463" alt="Screenshot 2025-12-24 at 7 02 26 PM" src="https://github.com/user-attachments/assets/635163c7-e537-4fbf-9a65-00d2984a0c74" />|


Closes https://linear.app/a8c/issue/REDTWOO-95/allow-re-attempting-campaign-creation-and-ux-improvements-for-the

### Steps to test the changes in this Pull Request:
1. Install the plugin, connect accounts, and skip campaign creation during onboarding.
2. Verify that the **“Reddit Ads”** card shows a **“Create Campaign”** button to create a campaign from onboarding.
3. Click the **“Create Campaign”** button and ensure you are redirected to the campaign creation step of onboarding.
4. Create a campaign and verify that you are redirected to the settings page.
5. Verify that the **“Reddit Ads”** card now shows two buttons: one to go to the Reddit dashboard and another to create a new campaign on the Reddit side.

### Changelog entry
> Update - UX improvements for the Reddit Ads card.