### PR TITLE
REDTWOO-97: Ensure that switching businesses during onboarding connects the correct ad account.

### DIFF
--- a/includes/API/AdPartner/AdPartnerApi.php
+++ b/includes/API/AdPartner/AdPartnerApi.php
@@ -116,6 +116,13 @@ class AdPartnerApi {
 	 * @var AdApi
 	 */
 	public AdApi $ads;
+	/**
+	 * Handles Profiles operations.
+	 *
+	 * @since x.x.x
+	 * @var ProfilesApi
+	 */
+	public ProfilesApi $profiles;
 
 	/**
 	 * Private constructor to enforce singleton pattern.
@@ -138,6 +145,7 @@ class AdPartnerApi {
 		$this->ad_groups    = new AdGroupApi( $wcs );
 		$this->product_sets = new ProductSetApi( $wcs );
 		$this->ads          = new AdApi( $wcs );
+		$this->profiles     = new ProfilesApi( $wcs );
 	}
 
 	/**

--- a/includes/API/AdPartner/AdPartnerApi.php
+++ b/includes/API/AdPartner/AdPartnerApi.php
@@ -116,6 +116,7 @@ class AdPartnerApi {
 	 * @var AdApi
 	 */
 	public AdApi $ads;
+
 	/**
 	 * Handles Profiles operations.
 	 *

--- a/includes/API/AdPartner/ProfilesApi.php
+++ b/includes/API/AdPartner/ProfilesApi.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * API module for managing Ad Partner profiles.
+ *
+ * This class provides an interface for interacting with the Ad Partner's
+ * Profile API via WooCommerce Connect Server (WCS). It supports operations
+ * such as listing all profiles associated with the configured business.
+ *
+ * Requests are proxied through WCS, which manages authentication and
+ * secure communication with the Ad Partner's remote API.
+ *
+ * @since x.x.x
+ * @package RedditForWooCommerce\API\AdPartner
+ */
+
+namespace RedditForWooCommerce\API\AdPartner;
+
+use RedditForWooCommerce\API\AdPartner\BaseAdPartnerApi;
+use RedditForWooCommerce\Utils\Storage\Options;
+use RedditForWooCommerce\Utils\Storage\OptionDefaults;
+use WP_Error;
+
+/**
+ * API module for managing Ad Partner profiles.
+ *
+ * This class provides methods to fetch the list of profiles
+ * associated with the currently configured business. Profiles are used
+ * for ad targeting and campaign management within the Ad Partner’s platform.
+ *
+ * @since x.x.x
+ */
+class ProfilesApi extends BaseAdPartnerApi {
+
+	/**
+	 * Retrieves the list of profiles for the configured business.
+	 *
+	 * This method calls the Ad Partner API to return all profiles
+	 * associated with the business ID stored in plugin options
+	 * ({@see OptionDefaults::BUSINESS_ID}).
+	 *
+	 * If no business ID is set, a {@see WP_Error} is returned.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return \WP_REST_Response|WP_Error REST response containing the list of profiles
+	 *                                    or error if the business ID is not configured.
+	 */
+	public function list() {
+		$business_id = Options::get( OptionDefaults::BUSINESS_ID );
+
+		if ( ! $business_id ) {
+			return new WP_Error(
+				'business_id_not_set',
+				__( 'Business ID not found.', 'reddit-for-woocommerce' ),
+			);
+		}
+
+		return $this->wcs->proxy_get(
+			sprintf( '/ads/businesses/%s/profiles', rawurlencode( $business_id ) )
+		);
+	}
+}

--- a/includes/API/Site/Controllers/CampaignController.php
+++ b/includes/API/Site/Controllers/CampaignController.php
@@ -385,30 +385,28 @@ class CampaignController extends RESTBaseController {
 	}
 
 	/**
-	 * Get the profile ID.
+	 * Get the profile ID for the configured business.
+	 *
+	 * This method fetches all profiles for the configured business and returns the first profile ID.
 	 *
 	 * @return string|WP_Error Profile ID or WP_Error if profile ID is not found.
 	 */
 	private function get_profile_id() {
-		$profile_id = Options::get( OptionDefaults::PROFILE_ID );
+		// Get the list of profiles.
+		$profiles = $this->ad_partner_api->profiles->list();
+
+		if ( is_wp_error( $profiles ) ) {
+			return $profiles;
+		}
+
+		$profiles_data = $profiles->get_data();
+		$profile       = current( $profiles_data['data'] ?? array() );
+		$profile_id    = $profile['id'] ?? '';
 		if ( empty( $profile_id ) ) {
-			// Get the profile ID from the Reddit member.
-			$member = $this->ad_partner_api->members->me();
-
-			if ( is_wp_error( $member ) ) {
-				return $member;
-			}
-
-			$member_data = $member->get_data();
-			$profile_id  = $member_data['data']['id'] ?? '';
-			if ( empty( $profile_id ) ) {
-				return new WP_Error(
-					'profile_id_not_found',
-					__( 'Profile ID not found.', 'reddit-for-woocommerce' )
-				);
-			}
-
-			Options::set( OptionDefaults::PROFILE_ID, $profile_id );
+			return new WP_Error(
+				'profile_id_not_found',
+				__( 'Profile ID not found.', 'reddit-for-woocommerce' )
+			);
 		}
 
 		return $profile_id;

--- a/includes/API/Site/Controllers/RedditConnectionController.php
+++ b/includes/API/Site/Controllers/RedditConnectionController.php
@@ -338,7 +338,6 @@ class RedditConnectionController extends RESTBaseController {
 		Options::delete( OptionDefaults::CATALOG_ID );
 		Options::delete( OptionDefaults::FEED_STATUS );
 		Options::delete( OptionDefaults::WCS_PRODUCTS_TOKEN );
-		Options::delete( OptionDefaults::PROFILE_ID );
 		Options::delete( OptionDefaults::DUMMY_PURCHASE_TRACKED );
 		Options::delete( OptionDefaults::ADS_ACCOUNT_CURRENCY );
 		Transients::delete( TransientDefaults::REDDIT_ACCOUNT_EMAIL );
@@ -427,21 +426,6 @@ class RedditConnectionController extends RESTBaseController {
 			do_action( Helper::with_prefix( 'before_onboarding_complete' ) );
 
 			Options::set( OptionDefaults::ONBOARDING_STATUS, 'connected' );
-
-			// Set the profile ID.
-			$member = $this->ad_partner_api->members->me();
-
-			if ( is_wp_error( $member ) ) {
-				$logger = wc_get_logger();
-				$logger->alert(
-					'Reddit member not found.',
-				);
-			} else {
-				$member_data = $member->get_data();
-				if ( ! empty( $member_data['data'] ) ) {
-					Options::set( OptionDefaults::PROFILE_ID, $member_data['data']['id'] );
-				}
-			}
 
 			// Create a new catalog for the business.
 			$response = $this->ad_partner_api->catalog->create();

--- a/includes/API/Site/Controllers/RedditConnectionController.php
+++ b/includes/API/Site/Controllers/RedditConnectionController.php
@@ -331,6 +331,7 @@ class RedditConnectionController extends RESTBaseController {
 		Options::delete( OptionDefaults::PIXEL_ID );
 		Options::delete( OptionDefaults::IS_JETPACK_CONNECTED );
 		Options::delete( OptionDefaults::ONBOARDING_STATUS );
+		Options::delete( OptionDefaults::ONBOARDING_STEP );
 		Options::delete( OptionDefaults::LAST_EXPORT_TIMESTAMP );
 		Options::delete( OptionDefaults::EXPORT_FILE_PATH );
 		Options::delete( OptionDefaults::EXPORT_FILE_URL );
@@ -388,7 +389,10 @@ class RedditConnectionController extends RESTBaseController {
 						Options::delete( OptionDefaults::FEED_STATUS );
 					}
 				}
-				// Remove the dummy purchase tracked flag.
+				// Remove business specific options.
+				Options::delete( OptionDefaults::ONBOARDING_STATUS );
+				Options::delete( OptionDefaults::ONBOARDING_STEP );
+				Options::delete( OptionDefaults::ADS_ACCOUNT_CURRENCY );
 				Options::delete( OptionDefaults::DUMMY_PURCHASE_TRACKED );
 			}
 

--- a/includes/API/Site/Controllers/RedditConnectionController.php
+++ b/includes/API/Site/Controllers/RedditConnectionController.php
@@ -389,6 +389,8 @@ class RedditConnectionController extends RESTBaseController {
 						Options::delete( OptionDefaults::FEED_STATUS );
 					}
 				}
+				// Remove the dummy purchase tracked flag.
+				Options::delete( OptionDefaults::DUMMY_PURCHASE_TRACKED );
 			}
 
 			Options::set( OptionDefaults::BUSINESS_ID, sanitize_text_field( $params['business_id'] ) );

--- a/includes/API/Site/Controllers/RedditConnectionController.php
+++ b/includes/API/Site/Controllers/RedditConnectionController.php
@@ -378,6 +378,19 @@ class RedditConnectionController extends RESTBaseController {
 		$params = $request->get_json_params();
 
 		if ( isset( $params['business_id'] ) ) {
+			$stored_business_id = Options::get( OptionDefaults::BUSINESS_ID );
+			// Check if the business id has changed, if so, delete the catalog and feed to create a new one with the new business id.
+			if ( ! empty( $stored_business_id ) && sanitize_text_field( wp_unslash( $params['business_id'] ) ) !== $stored_business_id ) {
+				$catalog_id = Options::get( OptionDefaults::CATALOG_ID );
+				if ( ! empty( $catalog_id ) ) {
+					$delete_catalog = $this->ad_partner_api->catalog->delete( $catalog_id );
+					if ( ! is_wp_error( $delete_catalog ) ) {
+						Options::delete( OptionDefaults::CATALOG_ID );
+						Options::delete( OptionDefaults::FEED_STATUS );
+					}
+				}
+			}
+
 			Options::set( OptionDefaults::BUSINESS_ID, sanitize_text_field( $params['business_id'] ) );
 		}
 

--- a/includes/Utils/Storage/OptionDefaults.php
+++ b/includes/Utils/Storage/OptionDefaults.php
@@ -174,13 +174,6 @@ final class OptionDefaults {
 	public const WCS_PRODUCTS_TOKEN = 'wcs_products_token';
 
 	/**
-	 * Option key to store the Ad Partner's Profile ID.
-	 *
-	 * @since 0.1.0
-	 */
-	public const PROFILE_ID = 'profile_id';
-
-	/**
 	 * Option key to store the dummy purchase tracked status.
 	 *
 	 * @since 0.1.0
@@ -225,7 +218,6 @@ final class OptionDefaults {
 			self::EXPORT_PRODUCT_IDS     => array(),
 			self::LAST_EXPORT_TIMESTAMP  => 0,
 			self::WCS_PRODUCTS_TOKEN     => '',
-			self::PROFILE_ID             => '',
 			self::DUMMY_PURCHASE_TRACKED => 'no',
 			self::ADS_ACCOUNT_CURRENCY   => get_woocommerce_currency(),
 		);

--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -342,6 +342,7 @@ export async function upsertBusinessAccount(
 			},
 		} );
 
+		await fetchExistingAdsAccounts();
 		return receiveRedditAccountConfig( response );
 	} catch ( error ) {
 		handleApiError(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

As reported in REDTWOO-97, when switching the business from A to B, the ad accounts were not being updated for the newly selected business. This PR fixes the issue by fetching ad accounts for the selected business instead of continuing to use the ad accounts from the previously selected business.

Closes https://linear.app/a8c/issue/REDTWOO-97/switching-businesses-from-a-to-b-issues

### Steps to test the changes in this Pull Request:

1. Register for a Reddit business account and ensure it has multiple businesses. You can do this by inviting your account to another business.
2. Install the plugin, connect the accounts, and click **Edit** to change the connected business.
3. Change the business to a different one from the currently selected business.
4. Verify that the connected ad account belongs to the newly selected business.
5. Verify that the catalog is created under the newly selected business and deleted from the previously selected business.

### Changelog entry

> Fix – Ensure that switching businesses during onboarding connects the correct ad account.