### PR TITLE
REDTWOO-101: Fix flaky PHPUnit test in `ProductExportServiceTest`

### DIFF
--- a/tests/phpunit/Unit/Admin/Export/Service/ProductExportServiceTest.php
+++ b/tests/phpunit/Unit/Admin/Export/Service/ProductExportServiceTest.php
@@ -130,6 +130,7 @@ class ProductExportServiceTest extends WP_UnitTestCase {
 
 		$product_2 = new \WC_Product_Simple();
 		$product_2->set_name( 'Sample Product' );
+		$product_2->set_date_created( time() + 1 );
 		$product_2->save();
 
 		Options::set( OptionDefaults::EXPORT_PRODUCT_IDS, array( $product->get_id(), $product_2->get_id() ) );
@@ -162,25 +163,25 @@ class ProductExportServiceTest extends WP_UnitTestCase {
 			$csv[0]
 		);
 
-		$this->assertEquals( (string) $product->get_id(), $csv[1][0] );
-		$this->assertEquals( 'Test Product', $csv[1][1] );
+		$this->assertEquals( (string) $product_2->get_id(), $csv[1][0] );
+		$this->assertEquals( 'Sample Product', $csv[1][1] );
 		$this->assertEquals( '', $csv[1][2] );
-		$this->assertStringContainsString( '?product=test-product', $csv[1][3] );
+		$this->assertStringContainsString( '?product=sample-product', $csv[1][3] );
 		$this->assertEquals( '', $csv[1][4] );
-		$this->assertEquals( '29.99 USD', $csv[1][5] );
+		$this->assertEquals( '0 USD', $csv[1][5] );
 		$this->assertEquals( '', $csv[1][6] );
 		$this->assertEquals( '', $csv[1][7] );
-		$this->assertEquals( 'in_stock', $csv[1][8] );
+		$this->assertEquals( 'out_of_stock', $csv[1][8] );
 
-		$this->assertEquals( (string) $product_2->get_id(), $csv[2][0] );
-		$this->assertEquals( 'Sample Product', $csv[2][1] );
+		$this->assertEquals( (string) $product->get_id(), $csv[2][0] );
+		$this->assertEquals( 'Test Product', $csv[2][1] );
 		$this->assertEquals( '', $csv[2][2] );
-		$this->assertStringContainsString( '?product=sample-product', $csv[2][3] );
+		$this->assertStringContainsString( '?product=test-product', $csv[2][3] );
 		$this->assertEquals( '', $csv[2][4] );
-		$this->assertEquals( '0 USD', $csv[2][5] );
+		$this->assertEquals( '29.99 USD', $csv[2][5] );
 		$this->assertEquals( '', $csv[2][6] );
 		$this->assertEquals( '', $csv[2][7] );
-		$this->assertEquals( 'out_of_stock', $csv[2][8] );
+		$this->assertEquals( 'in_stock', $csv[2][8] );
 
 		if ( file_exists( $file_path ) ) {
 			unlink( $file_path );


### PR DESCRIPTION
### Changes proposed in this Pull Request:
PR fixes the flaky PHPUnit test in `ProductExportServiceTest`.

The flakiness was caused by the order of products exported in the CSV. The ordering is based on the date, and in the PHPUnit environment both products were sometimes created at the same time. As a result, the export order changed intermittently, causing assertion failures against the expected values.

This PR adds a +1 second offset to the second product to ensure the products do not share the same created/modified timestamp, making the export order deterministic.

> [!NOTE]
> Alternatively, we could update the `wc_get_products` parameters to use a different `order_by` field. However, it is better to keep the default behavior aligned with Woo core for now.

Closes https://linear.app/a8c/issue/REDTWOO-101/investigate-flaky-phpunit-test-in-productexportservicetest

### Steps to test the changes in this Pull Request:
1. Try running PHPUnit Test GH action multiple times and make sure it pass every time.

### Changelog entry

> Dev – Fix flaky PHPUnit test in `ProductExportServiceTest`