### PR TITLE
[REDTWOO-109] Scope Reddit JS Bundle to Load Only on Reddit Admin Page

### DIFF
--- a/includes/Admin/Assets.php
+++ b/includes/Admin/Assets.php
@@ -59,8 +59,10 @@ class Assets {
 	public function enqueue_assets(): void {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$page = sanitize_text_field( wp_unslash( $_GET['page'] ?? '' ) );
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$path = sanitize_text_field( wp_unslash( $_GET['path'] ?? '' ) );
 
-		if ( ! ( 'wc-admin' === $page ) ) {
+		if ( ! ( 'wc-admin' === $page && str_contains( $path, '/reddit' ) ) ) {
 			return;
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes: https://linear.app/a8c/issue/REDTWOO-109/scope-reddit-js-bundle-to-load-only-on-reddit-admin-page

### Screenshots:

N/A


### Detailed test instructions:

1. Open WP admin (`/wp-admin/`)
2. Open the inspector; in the Elements section search for `reddit-for-woocommerce` - you should not have any matches for JS / CSS from the plugin (there may be data from settings)
3. Open the WooCommerce page (`/wp-admin/admin.php?page=wc-admin`)
4. Open the inspector; in the Elements section search for `reddit-for-woocommerce` - you should not have any matches for JS / CSS from the plugin (there may be data from settings)
3. Open the Marketing -> Reddit (`/wp-admin/admin.php?page=wc-admin&path=%2Freddit%2Fsettings`)
4. Open the inspector; in the Elements section search for `reddit-for-woocommerce` - you should find several matches; confirm you can see the JS (e.g. `/wp-content/plugins/reddit-for-woocommerce/js/build/index.js?ver=3794a2a7e65f6afe4ed5`) and CSS (e.g. `/wp-content/plugins/reddit-for-woocommerce/js/build/index.css?ver=3794a2a7e65f6afe4ed5`) - note the version ID may be different

### Additional details:

> Update - Scope Reddit JS Bundle to Load Only on Reddit Admin Page
