### PR TITLE
Fix/REDTWOO-110: Fix ESLint warnings

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -11,6 +11,12 @@
 		"font-weight-notation": null,
 		"no-descending-specificity": null,
 		"rule-empty-line-before": null,
-		"selector-class-pattern": null
+		"selector-class-pattern": null,
+		"selector-pseudo-class-no-unknown": [
+			true,
+			{
+				"ignorePseudoClasses": ["global"]
+			}
+		]
 	}
 }

--- a/js/src/components/app-input-control/index.js
+++ b/js/src/components/app-input-control/index.js
@@ -4,7 +4,7 @@
 import classnames from 'classnames';
 import { __, sprintf } from '@wordpress/i18n';
 import { forwardRef } from '@wordpress/element';
-import { __experimentalInputControl as InputControl } from '@wordpress/components';
+import { __experimentalInputControl as InputControl } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 
 /**
  * Internal dependencies

--- a/js/src/components/paid-ads/budget-setup/budget-setup.js
+++ b/js/src/components/paid-ads/budget-setup/budget-setup.js
@@ -127,14 +127,7 @@ export default function BudgetSetup( { hideRecommendations = false } ) {
 		}
 
 		setValue( 'amount', normalizedNextAmount );
-	}, [
-		budgetRecommendation,
-		currencyPrecision,
-		setValue,
-		values.amount,
-		values.currentAmount,
-		values.level,
-	] );
+	}, [ budgetRecommendation, currencyPrecision, setValue, values ] );
 
 	const options = [ 'high', 'recommended', 'low' ].reduce( ( acc, level ) => {
 		const item = hideRecommendations

--- a/js/src/hooks/useCreateCatalog.js
+++ b/js/src/hooks/useCreateCatalog.js
@@ -88,7 +88,7 @@ const useCreateCatalog = () => {
 				setLoading( false );
 			}
 		},
-		[ createNotice, setCreatedCatalogId, setLoading ]
+		[ createNotice, invalidateResolution, setCreatedCatalogId, setLoading ]
 	);
 
 	return { createCatalog, loading, createdCatalogId, errorCode };

--- a/js/src/hooks/useMenuLinkUpdate.js
+++ b/js/src/hooks/useMenuLinkUpdate.js
@@ -41,7 +41,7 @@ function useMenuLinkUpdate() {
 		) {
 			setupLink.setAttribute( 'href', redirectUrl );
 		}
-	}, [ setupLink ] );
+	}, [ setupLink, status ] );
 }
 
 export default useMenuLinkUpdate;

--- a/js/src/pages/onboarding/setup-stepper/setup-accounts/index.js
+++ b/js/src/pages/onboarding/setup-stepper/setup-accounts/index.js
@@ -82,7 +82,7 @@ const SetupAccounts = ( props ) => {
 		( async () => {
 			await updateSettings( { productsToken: productsTokenParam } );
 		} )();
-	}, [ productsTokenParam ] );
+	}, [ productsTokenParam, updateSettings ] );
 
 	if ( isLoadingJetpack || ! hasResolvedRedditAccount ) {
 		return <AppSpinner />;

--- a/js/src/pages/settings/product-catalog/index.js
+++ b/js/src/pages/settings/product-catalog/index.js
@@ -178,7 +178,7 @@ const ProductCatalog = () => {
 		if ( shouldTriggerExport && hasFinishedResolution ) {
 			generateCsv();
 		}
-	}, [ shouldTriggerExport, hasFinishedResolution ] );
+	}, [ shouldTriggerExport, hasFinishedResolution, generateCsv ] );
 
 	useEffect( () => {
 		if ( lastExportTimeStamp ) {


### PR DESCRIPTION
Fixes eslint warnings and updates stylelint rules to ignore :global selector warning

https://linear.app/a8c/issue/REDTWOO-110/fix-existing-eslint-errors-across-codebase

### Detailed test instructions:

1. Install dependencies by running `npm install`
2. Run the linter for JS files with `npm run lint:js`
3. Ensure no errors or warnings are flagged
4. Do the same with the CSS linter `npm run lint:css`
5. Ensure no errors or warnings are flagged