### PR TITLE
[REDTWOO-71] QA - Disconnect fails when Catalog Manager role is removed after initial setup 

### DIFF
--- a/includes/API/Site/Controllers/RedditConnectionController.php
+++ b/includes/API/Site/Controllers/RedditConnectionController.php
@@ -297,14 +297,14 @@ class RedditConnectionController extends RESTBaseController {
 		if ( $catalog_id ) {
 			$delete_catalog_response = $this->ad_partner_api->catalog->delete( $catalog_id );
 
+			// If catalog deletion fails, log the error but don't stop the disconnection process.
 			if ( is_wp_error( $delete_catalog_response ) ) {
-				return new WP_REST_Response(
-					array(
-						'status'  => 'error',
-						'message' => $delete_catalog_response->get_error_message(),
-						'data'    => $delete_catalog_response->get_error_data(),
-					),
-					500
+				$error_data = $delete_catalog_response->get_error_data();
+				$error_body = isset( $error_data['body'] ) ? json_decode( $error_data['body'], true ) : array();
+				$logger     = wc_get_logger();
+				$logger->alert(
+					'Deleting catalog failed with error code: ' . $delete_catalog_response->get_error_code(),
+					$error_body
 				);
 			}
 		}

--- a/tests/phpunit/Unit/API/Site/Controllers/RedditConnectionControllerTest.php
+++ b/tests/phpunit/Unit/API/Site/Controllers/RedditConnectionControllerTest.php
@@ -1,0 +1,249 @@
+<?php
+/**
+ * Unit tests for RedditConnectionController::delete_connection().
+ *
+ * @package RedditForWooCommerce\Tests\Unit\API\Site\Controllers
+ */
+
+namespace RedditForWooCommerce\Tests\Unit\API\Site\Controllers;
+
+use WP_UnitTestCase;
+use WP_REST_Response;
+use WP_Error;
+use RedditForWooCommerce\API\Site\Controllers\RedditConnectionController;
+use RedditForWooCommerce\API\AdPartner\AdPartnerApi;
+use RedditForWooCommerce\API\AdPartner\CatalogApi;
+use RedditForWooCommerce\API\AdPartner\CampaignApi;
+use RedditForWooCommerce\Connection\WcsClient;
+use RedditForWooCommerce\Utils\Storage\Options;
+use RedditForWooCommerce\Utils\Storage\OptionDefaults;
+use RedditForWooCommerce\Utils\Helper;
+
+/**
+ * @covers \RedditForWooCommerce\API\Site\Controllers\RedditConnectionController::delete_connection
+ */
+class RedditConnectionControllerTest extends WP_UnitTestCase {
+
+	/**
+	 * @var WcsClient
+	 */
+	private $wcs_mock;
+
+	/**
+	 * @var AdPartnerApi
+	 */
+	private $ad_partner_api_mock;
+
+	/**
+	 * @var CatalogApi
+	 */
+	private $catalog_mock;
+
+	/**
+	 * @var CampaignApi
+	 */
+	private $campaign_mock;
+
+	/**
+	 * @var RedditConnectionController
+	 */
+	private $controller;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->wcs_mock            = $this->createMock( WcsClient::class );
+		$this->ad_partner_api_mock = $this->createMock( AdPartnerApi::class );
+		$this->catalog_mock        = $this->createMock( CatalogApi::class );
+		$this->campaign_mock       = $this->createMock( CampaignApi::class );
+
+		$this->ad_partner_api_mock->catalog   = $this->catalog_mock;
+		$this->ad_partner_api_mock->campaigns = $this->campaign_mock;
+
+		$this->controller = new RedditConnectionController(
+			$this->wcs_mock,
+			$this->ad_partner_api_mock
+		);
+	}
+
+	public function tear_down(): void {
+		Options::delete( OptionDefaults::CATALOG_ID );
+		Options::delete( OptionDefaults::AD_ACCOUNT_ID );
+		Options::delete( OptionDefaults::BUSINESS_ID );
+		Options::delete( OptionDefaults::BUSINESS_NAME );
+		Options::delete( OptionDefaults::AD_ACCOUNT_NAME );
+		Options::delete( OptionDefaults::PIXEL_ID );
+		Options::delete( OptionDefaults::IS_JETPACK_CONNECTED );
+		Options::delete( OptionDefaults::ONBOARDING_STATUS );
+		Options::delete( OptionDefaults::ONBOARDING_STEP );
+		Options::delete( OptionDefaults::CAMPAIGN_IDS );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Sets up plugin options to simulate a connected state.
+	 *
+	 * @param string $catalog_id    Catalog ID to set (empty string = no catalog).
+	 * @param string $ad_account_id Ad account ID.
+	 * @param array  $campaign_ids  Campaign IDs.
+	 */
+	private function set_up_connected_state( string $catalog_id = 'cat_123', string $ad_account_id = 'acc_456', array $campaign_ids = array() ): void {
+		if ( $catalog_id ) {
+			Options::set( OptionDefaults::CATALOG_ID, $catalog_id );
+		}
+		Options::set( OptionDefaults::AD_ACCOUNT_ID, $ad_account_id );
+		Options::set( OptionDefaults::BUSINESS_ID, 'biz_789' );
+		Options::set( OptionDefaults::BUSINESS_NAME, 'Test Business' );
+		Options::set( OptionDefaults::AD_ACCOUNT_NAME, 'Test Account' );
+		Options::set( OptionDefaults::PIXEL_ID, 'pix_101' );
+		Options::set( OptionDefaults::IS_JETPACK_CONNECTED, 'yes' );
+		Options::set( OptionDefaults::ONBOARDING_STATUS, 'complete' );
+		Options::set( OptionDefaults::ONBOARDING_STEP, 'done' );
+		Options::set( OptionDefaults::CAMPAIGN_IDS, $campaign_ids );
+	}
+
+	/**
+	 * Configures the WCS mock to return a successful disconnect response.
+	 */
+	private function mock_successful_stop_connection(): void {
+		$this->wcs_mock->method( 'proxy_get' )
+			->with( 'connection/disconnect' )
+			->willReturn( new WP_REST_Response( array( 'status' => 'disconnected' ), 200 ) );
+	}
+
+	public function test_disconnect_succeeds_when_catalog_deletion_succeeds() {
+		$this->set_up_connected_state();
+		$this->mock_successful_stop_connection();
+
+		$this->catalog_mock->expects( $this->once() )
+			->method( 'delete' )
+			->with( 'cat_123' )
+			->willReturn( new WP_REST_Response( array( 'status' => 'ok' ), 200 ) );
+
+		$response = $this->controller->delete_connection();
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertEquals( 'disconnected', $response->get_data()['status'] );
+	}
+
+	public function test_disconnect_succeeds_when_catalog_deletion_returns_403() {
+		$this->set_up_connected_state();
+		$this->mock_successful_stop_connection();
+
+		$this->catalog_mock->expects( $this->once() )
+			->method( 'delete' )
+			->with( 'cat_123' )
+			->willReturn(
+				new WP_Error(
+					'reddit_for_woocommerce_request_failed',
+					'Request failed',
+					array( 'body' => '{"error":{"code":403,"message":"no permissions to Delete Catalog action"}}' )
+				)
+			);
+
+		$response = $this->controller->delete_connection();
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertEquals( 'disconnected', $response->get_data()['status'] );
+	}
+
+	public function test_disconnect_succeeds_when_no_catalog_exists() {
+		$this->set_up_connected_state( '' );
+		$this->mock_successful_stop_connection();
+
+		$this->catalog_mock->expects( $this->never() )
+			->method( 'delete' );
+
+		$response = $this->controller->delete_connection();
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertEquals( 'disconnected', $response->get_data()['status'] );
+	}
+
+	public function test_disconnect_fails_when_stop_connection_returns_error() {
+		$this->set_up_connected_state( '' );
+
+		$this->wcs_mock->method( 'proxy_get' )
+			->with( 'connection/disconnect' )
+			->willReturn( new WP_Error( 'connection_error', 'Connection failed' ) );
+
+		$response = $this->controller->delete_connection();
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertEquals( 500, $response->get_status() );
+		$this->assertEquals( 'error', $response->get_data()['status'] );
+	}
+
+	public function test_options_are_cleared_after_disconnect_despite_catalog_failure() {
+		$this->set_up_connected_state();
+		$this->mock_successful_stop_connection();
+
+		$this->catalog_mock->method( 'delete' )
+			->willReturn( new WP_Error( 'forbidden', 'Forbidden', array( 'body' => '{}' ) ) );
+
+		$this->controller->delete_connection();
+
+		$defaults = OptionDefaults::get_all();
+		$this->assertEquals( $defaults[ OptionDefaults::BUSINESS_ID ], Options::get( OptionDefaults::BUSINESS_ID ) );
+		$this->assertEquals( $defaults[ OptionDefaults::AD_ACCOUNT_ID ], Options::get( OptionDefaults::AD_ACCOUNT_ID ) );
+		$this->assertEquals( $defaults[ OptionDefaults::CATALOG_ID ], Options::get( OptionDefaults::CATALOG_ID ) );
+		$this->assertEquals( $defaults[ OptionDefaults::PIXEL_ID ], Options::get( OptionDefaults::PIXEL_ID ) );
+	}
+
+	public function test_options_not_cleared_when_stop_connection_fails() {
+		$this->set_up_connected_state( '' );
+
+		$this->wcs_mock->method( 'proxy_get' )
+			->with( 'connection/disconnect' )
+			->willReturn( new WP_Error( 'connection_error', 'Connection failed' ) );
+
+		$this->controller->delete_connection();
+
+		$this->assertEquals( 'biz_789', Options::get( OptionDefaults::BUSINESS_ID ) );
+		$this->assertEquals( 'acc_456', Options::get( OptionDefaults::AD_ACCOUNT_ID ) );
+		$this->assertEquals( 'yes', Options::get( OptionDefaults::IS_JETPACK_CONNECTED ) );
+	}
+
+	public function test_campaigns_are_archived_when_catalog_deletion_fails() {
+		$this->set_up_connected_state( 'cat_123', 'acc_456', array( 'camp_1', 'camp_2' ) );
+		$this->mock_successful_stop_connection();
+
+		$this->catalog_mock->method( 'delete' )
+			->willReturn( new WP_Error( 'forbidden', 'Forbidden', array( 'body' => '{}' ) ) );
+
+		$archived_ids = array();
+		$this->campaign_mock->expects( $this->exactly( 2 ) )
+			->method( 'update' )
+			->willReturnCallback(
+				function ( $campaign_id, $data ) use ( &$archived_ids ) {
+					$archived_ids[] = $campaign_id;
+					$this->assertEquals( array( 'configured_status' => 'ARCHIVED' ), $data );
+					return new WP_REST_Response( array(), 200 );
+				}
+			);
+
+		$response = $this->controller->delete_connection();
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertEquals( 'disconnected', $response->get_data()['status'] );
+		$this->assertEquals( array( 'camp_1', 'camp_2' ), $archived_ids );
+	}
+
+	public function test_disconnect_action_fires_on_success() {
+		$this->set_up_connected_state( '' );
+		$this->mock_successful_stop_connection();
+
+		$action_fired = false;
+		add_action(
+			Helper::with_prefix( 'reddit_disconnected' ),
+			function () use ( &$action_fired ) {
+				$action_fired = true;
+			}
+		);
+
+		$this->controller->delete_connection();
+
+		$this->assertTrue( $action_fired );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/REDTWOO-71/qa-disconnect-fails-when-catalog-manager-role-is-removed-after-initial

### Screenshots:

N/A

### Detailed test instructions:

#### Pre-requisites:

- A WordPress site with Reddit for WooCommerce installed and activated.
- Reddit Ads Account Owner: A Reddit account that owns the Reddit Ads business/ad account. This person manages roles and invitations.
- Reddit Ads Member: A second Reddit account that is invited to the business with the Catalog Manager role. This is the account used to connect the plugin.

#### Test 1: Disconnect succeeds when Catalog Manager role has been removed

1. Using the Member account, complete the full plugin onboarding (Jetpack connected, Reddit account connected, business/ad account/pixel selected, catalog created).
2. Verify the plugin Settings page shows a connected state.
3. Using the Owner account in the Reddit Ads dashboard, remove the Catalog Manager role from the Member account (or remove the Member from the business entirely).
4. Return to WordPress admin (still authenticated as the WP user that connected via the Member Reddit account). Navigate to Marketing > Reddit for WooCommerce > Settings.
5. Click Disconnect.
6. Confirm the disconnect in the modal.

Expected results:
1. The disconnect completes successfully with no error message.
2. You are returned to the setup/get-started screen.
3. Refreshing the page still shows the disconnected/setup state (local data was fully cleared).

#### Test 2: Disconnect succeeds when Catalog Manager role is still present (regression)

1. Using the Member account (with Catalog Manager role intact), complete the full plugin onboarding.
2. Verify the plugin Settings page shows a connected state.
3. Navigate to Marketing > Reddit for WooCommerce > Settings.
4. Click Disconnect.
5. Confirm the disconnect in the modal.

Expected results:
1. The disconnect completes successfully with no error message.
2. You are returned to the setup/get-started screen.
3. Refreshing the page still shows the disconnected/setup state.

#### Test 3: Disconnect succeeds when no catalog was created (regression)

1. Connect the plugin but do not complete the catalog creation step (disconnect before finishing onboarding, or connect an account that has no catalog).
2. Navigate to Marketing > Reddit for WooCommerce > Settings.
3. Click "Disconnect Reddit account".
4. Confirm the disconnect in the modal.

Expected results:
1. The disconnect completes successfully with no error message.
2. You are returned to the setup/get-started screen.

#### Test 4: Campaigns are archived during disconnect with removed role

1. Using the Member account (with Catalog Manager role), complete the full plugin onboarding including creating at least one campaign.
2. Using the Owner account, remove the Catalog Manager role from the Member account.
3. In WordPress admin, navigate to Marketing > Reddit

Expected results:
1. The disconnect completes successfully with no error message.
2. Using the Owner account, check the Reddit Ads dashboard — campaigns created by the plugin should be in an Archived state (or, if the Member also lost campaign permissions, the campaigns remain in their previous state but the disconnect still succeeds).

#### Test 5: Re-onboarding works after disconnect with removed role

1. Complete Test 1 (disconnect after role removal).
2. From the setup / get-started screen, click Connect to begin onboarding again.

Expected results:
1. The onboarding wizard starts cleanly.
2. No leftover data from the previous connection is shown (no pre-filled business name, ad account, pixel, etc.).
3. A fresh connection can be established using the same or a different Reddit account.

### Additional details:

> Fix - Ensure Reddit account can be disconnected where user role has been removed in Reddit.
