### PR TITLE
[REDTWOO-118] Add a pull request template to the repository

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,43 @@
+### Changes proposed in this Pull Request:
+
+<!-- You can erase any parts of this template not applicable to your Pull Request. -->
+
+Closes # .
+
+_Replace this with a good description of your changes & reasoning._
+
+
+### Screenshots:
+
+<!--- Optional --->
+
+
+### Detailed test instructions:
+<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->
+
+1. 
+2. 
+3. 
+
+
+### Additional details:
+
+<!--
+Optional.
+Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
+Each line should start with change type prefix`(Fix|Add|…) - `, for example:
+> Break - A change breaking previous API or functionality.
+> Add - A new feature, function or functionality was added.
+> Update - Big changes to something that wasn't broken.
+> Fix - Took care of something that wasn't working.
+> Tweak - Small change, that isn't actually very important.
+> Dev - Developer-facing only change.
+> Doc - Updated customer or developer facing documentation
+
+If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
+
+Add the `changelog: none` label if no changelog entry is needed.
+-->
+### Changelog entry
+
+>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/REDTWOO-118/add-a-pull-request-template-to-the-repository

### Screenshots:

N/A


### Detailed test instructions:

1. Create a new PR (with a temporary / test change)
2. Verify that the PR creation screen includes the template

### Additional details:

> Add - Added PR template