### PR TITLE
Compatibility testing with WooCommerce 10.7

### DIFF
--- a/reddit-for-woocommerce.php
+++ b/reddit-for-woocommerce.php
@@ -10,10 +10,10 @@
  * Requires Plugins: woocommerce
  * Requires PHP: 7.4
  * PHP tested up to: 8.4
- * Requires at least: 6.7
+ * Requires at least: 6.8
  * Tested up to: 6.9
- * WC requires at least: 10.2
- * WC tested up to: 10.4
+ * WC requires at least: 10.5
+ * WC tested up to: 10.7
  * Woo:
  *
  * License: GNU General Public License v3.0


### PR DESCRIPTION
### All Submissions:

* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

- Dev - Bump WooCommerce "tested up to" version 10.7.
- Dev - Bump WooCommerce minimum supported version to 10.5.
- Dev - Bump WordPress minimum supported version to 6.8.





Closes  https://linear.app/a8c/issue/REDTWOO-119/compatibility-testing-with-woo-107-beta-1

### Steps to test the changes in this Pull Request:

1. Run the e2e test using GitHub action to test this PR.
2. All tests should be passed. 
3. Manually check plugin setup and plugin core functionality. 
 

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Dev - Bump WooCommerce "tested up to" version 10.7.
> Dev - Bump WooCommerce minimum supported version to 10.5.
> Dev - Bump WordPress minimum supported version to 6.8.



