### PR TITLE
REDTWOO-129: Add webpack config

### DIFF
--- a/js/src/meta-boxes/channel-visibility/index.js
+++ b/js/src/meta-boxes/channel-visibility/index.js
@@ -1,0 +1,4 @@
+document.addEventListener( 'DOMContentLoaded', () => {
+	// eslint-disable-next-line no-console
+	console.log( 'channel-visibility entrypoint' );
+} );

--- a/js/src/meta-boxes/order-attribution/index.js
+++ b/js/src/meta-boxes/order-attribution/index.js
@@ -1,0 +1,4 @@
+document.addEventListener( 'DOMContentLoaded', () => {
+	// eslint-disable-next-line no-console
+	console.log( 'order-attribution entrypoint' );
+} );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -85,6 +85,16 @@ const webpackConfig = {
 	entry: () => ( {
 		...defaultConfig.entry(),
 		tracking: path.resolve( process.cwd(), 'js/src/tracking', 'index.js' ),
+		'order-attribution': path.resolve(
+			process.cwd(),
+			'js/src/meta-boxes/order-attribution',
+			'index.js'
+		),
+		'channel-visibility-meta-box': path.resolve(
+			process.cwd(),
+			'js/src/meta-boxes/channel-visibility',
+			'index.js'
+		),
 	} ),
 	output: {
 		...defaultConfig.output,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/REDTWOO-129/add-webpack-entries-and-the-jssrcmeta-boxes-scaffolding

### Screenshots:

N/A

### Detailed test instructions:

1. Run `npm run build`
2. Check in the js/build folder that the following assets files are generated:
  - `js/build/order-attribution.asset.php`
  - `js/build/channel-visibility-meta-box.asset.php`

### Additional details:

> Add - Product placement webpack configuration and entrypoints