### PR TITLE
[REDTWOO-124] Add order-attribution helpers in PHP

### DIFF
--- a/includes/Admin/MetaBox/OrderAttributionData.php
+++ b/includes/Admin/MetaBox/OrderAttributionData.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Order attribution data helper for the Edit Order admin screen.
+ *
+ * @package RedditForWooCommerce\Admin\MetaBox
+ * @since 0.1.0
+ */
+
+namespace RedditForWooCommerce\Admin\MetaBox;
+
+use Automattic\WooCommerce\Utilities\OrderUtil;
+
+/**
+ * Provides helpers for determining whether the current Edit Order screen
+ * is attributed to Reddit.
+ *
+ * @since 0.1.0
+ */
+class OrderAttributionData {
+
+	/**
+	 * Returns true when the current admin screen is the WooCommerce Edit Order screen.
+	 *
+	 * Guards against a null return from get_current_screen(), which can occur before
+	 * the current_screen action fires. Delegates to OrderUtil::is_order_edit_screen()
+	 * which handles both HPOS (woocommerce_page_wc-orders) and legacy (shop_order) screens.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @return bool
+	 */
+	public function is_wc_order_edit_screen(): bool {
+		if ( null === get_current_screen() ) {
+			return false;
+		}
+		return OrderUtil::is_order_edit_screen( 'shop_order' );
+	}
+
+	/**
+	 * Returns 'reddit' when the order currently being edited is attributed to Reddit.
+	 *
+	 * Returns null in every other case — not on the edit order screen, missing or
+	 * invalid order ID, deleted/trashed order, attribution meta absent or any value
+	 * other than the exact string 'reddit'.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @return string|null
+	 */
+	public function get_order_attribution_source_for_edit_screen(): ?string {
+		if ( ! $this->is_wc_order_edit_screen() ) {
+			return null;
+		}
+
+		$order_id = $this->get_order_id_from_request();
+		if ( ! $order_id ) {
+			return null;
+		}
+
+		$order = wc_get_order( $order_id );
+		if ( ! $order ) {
+			return null;
+		}
+
+		$source = $order->get_meta( '_wc_order_attribution_utm_source', true );
+
+		return 'reddit' === $source ? 'reddit' : null;
+	}
+
+	/**
+	 * Resolves the order ID from the current request.
+	 *
+	 * Checks the 'id' parameter first (HPOS), then falls back to 'post' (legacy posts storage).
+	 * Uses filter_input() rather than direct $_GET access to satisfy PHPCS
+	 * WordPress.Security.NonceVerification rules without suppression comments.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @return int Zero when no valid order ID is present.
+	 */
+	protected function get_order_id_from_request(): int {
+		$order_id = absint( filter_input( INPUT_GET, 'id', FILTER_VALIDATE_INT ) );
+		if ( ! $order_id ) {
+			$order_id = absint( filter_input( INPUT_GET, 'post', FILTER_VALIDATE_INT ) );
+		}
+		return $order_id;
+	}
+}

--- a/tests/phpunit/Unit/Admin/MetaBox/OrderAttributionDataTest.php
+++ b/tests/phpunit/Unit/Admin/MetaBox/OrderAttributionDataTest.php
@@ -42,7 +42,7 @@ class OrderAttributionDataTest extends WP_UnitTestCase {
 	 * @param bool $mock_screen   Value returned by is_wc_order_edit_screen().
 	 * @return OrderAttributionData
 	 */
-	private function create_testable_attribution_data( int $mock_order_id, bool $mock_screen ): OrderAttributionData {
+	private function create_order_attribution( int $mock_order_id, bool $mock_screen ): OrderAttributionData {
 		return new class( $mock_order_id, $mock_screen ) extends OrderAttributionData {
 			private int $mock_order_id;
 			private bool $mock_screen;
@@ -67,9 +67,9 @@ class OrderAttributionDataTest extends WP_UnitTestCase {
 	 */
 	public function test_hpos_path_returns_reddit(): void {
 		$order            = $this->create_order_with_attribution( 'reddit' );
-		$attribution_data = $this->create_testable_attribution_data( $order->get_id(), true );
+		$order_attribution = $this->create_order_attribution( $order->get_id(), true );
 
-		$this->assertSame( 'reddit', $attribution_data->get_order_attribution_source_for_edit_screen() );
+		$this->assertSame( 'reddit', $order_attribution->get_order_attribution_source_for_edit_screen() );
 	}
 
 	/**
@@ -77,9 +77,9 @@ class OrderAttributionDataTest extends WP_UnitTestCase {
 	 */
 	public function test_legacy_path_returns_reddit(): void {
 		$order            = $this->create_order_with_attribution( 'reddit' );
-		$attribution_data = $this->create_testable_attribution_data( $order->get_id(), true );
+		$order_attribution = $this->create_order_attribution( $order->get_id(), true );
 
-		$this->assertSame( 'reddit', $attribution_data->get_order_attribution_source_for_edit_screen() );
+		$this->assertSame( 'reddit', $order_attribution->get_order_attribution_source_for_edit_screen() );
 	}
 
 	/**
@@ -87,18 +87,18 @@ class OrderAttributionDataTest extends WP_UnitTestCase {
 	 */
 	public function test_non_reddit_utm_source_returns_null(): void {
 		$order            = $this->create_order_with_attribution( 'google' );
-		$attribution_data = $this->create_testable_attribution_data( $order->get_id(), true );
+		$order_attribution = $this->create_order_attribution( $order->get_id(), true );
 
-		$this->assertNull( $attribution_data->get_order_attribution_source_for_edit_screen() );
+		$this->assertNull( $order_attribution->get_order_attribution_source_for_edit_screen() );
 	}
 
 	/**
 	 * No order ID in the request must return null even when on the correct screen.
 	 */
 	public function test_no_order_id_returns_null(): void {
-		$attribution_data = $this->create_testable_attribution_data( 0, true );
+		$order_attribution = $this->create_order_attribution( 0, true );
 
-		$this->assertNull( $attribution_data->get_order_attribution_source_for_edit_screen() );
+		$this->assertNull( $order_attribution->get_order_attribution_source_for_edit_screen() );
 	}
 
 	/**
@@ -106,8 +106,8 @@ class OrderAttributionDataTest extends WP_UnitTestCase {
 	 */
 	public function test_wrong_screen_returns_null(): void {
 		$order            = $this->create_order_with_attribution( 'reddit' );
-		$attribution_data = $this->create_testable_attribution_data( $order->get_id(), false );
+		$order_attribution = $this->create_order_attribution( $order->get_id(), false );
 
-		$this->assertNull( $attribution_data->get_order_attribution_source_for_edit_screen() );
+		$this->assertNull( $order_attribution->get_order_attribution_source_for_edit_screen() );
 	}
 }

--- a/tests/phpunit/Unit/Admin/MetaBox/OrderAttributionDataTest.php
+++ b/tests/phpunit/Unit/Admin/MetaBox/OrderAttributionDataTest.php
@@ -42,7 +42,7 @@ class OrderAttributionDataTest extends WP_UnitTestCase {
 	 * @param bool $mock_screen   Value returned by is_wc_order_edit_screen().
 	 * @return OrderAttributionData
 	 */
-	private function make_sut( int $mock_order_id, bool $mock_screen ): OrderAttributionData {
+	private function create_testable_attribution_data( int $mock_order_id, bool $mock_screen ): OrderAttributionData {
 		return new class( $mock_order_id, $mock_screen ) extends OrderAttributionData {
 			private int $mock_order_id;
 			private bool $mock_screen;
@@ -66,48 +66,48 @@ class OrderAttributionDataTest extends WP_UnitTestCase {
 	 * HPOS path: simulates the order ID arriving via the ?id= query parameter.
 	 */
 	public function test_hpos_path_returns_reddit(): void {
-		$order = $this->create_order_with_attribution( 'reddit' );
-		$sut   = $this->make_sut( $order->get_id(), true );
+		$order            = $this->create_order_with_attribution( 'reddit' );
+		$attribution_data = $this->create_testable_attribution_data( $order->get_id(), true );
 
-		$this->assertSame( 'reddit', $sut->get_order_attribution_source_for_edit_screen() );
+		$this->assertSame( 'reddit', $attribution_data->get_order_attribution_source_for_edit_screen() );
 	}
 
 	/**
 	 * Legacy path: simulates the order ID arriving via the ?post= query parameter.
 	 */
 	public function test_legacy_path_returns_reddit(): void {
-		$order = $this->create_order_with_attribution( 'reddit' );
-		$sut   = $this->make_sut( $order->get_id(), true );
+		$order            = $this->create_order_with_attribution( 'reddit' );
+		$attribution_data = $this->create_testable_attribution_data( $order->get_id(), true );
 
-		$this->assertSame( 'reddit', $sut->get_order_attribution_source_for_edit_screen() );
+		$this->assertSame( 'reddit', $attribution_data->get_order_attribution_source_for_edit_screen() );
 	}
 
 	/**
 	 * A non-reddit utm_source must return null.
 	 */
 	public function test_non_reddit_utm_source_returns_null(): void {
-		$order = $this->create_order_with_attribution( 'google' );
-		$sut   = $this->make_sut( $order->get_id(), true );
+		$order            = $this->create_order_with_attribution( 'google' );
+		$attribution_data = $this->create_testable_attribution_data( $order->get_id(), true );
 
-		$this->assertNull( $sut->get_order_attribution_source_for_edit_screen() );
+		$this->assertNull( $attribution_data->get_order_attribution_source_for_edit_screen() );
 	}
 
 	/**
 	 * No order ID in the request must return null even when on the correct screen.
 	 */
 	public function test_no_order_id_returns_null(): void {
-		$sut = $this->make_sut( 0, true );
+		$attribution_data = $this->create_testable_attribution_data( 0, true );
 
-		$this->assertNull( $sut->get_order_attribution_source_for_edit_screen() );
+		$this->assertNull( $attribution_data->get_order_attribution_source_for_edit_screen() );
 	}
 
 	/**
 	 * A valid reddit-attributed order must still return null when not on the edit order screen.
 	 */
 	public function test_wrong_screen_returns_null(): void {
-		$order = $this->create_order_with_attribution( 'reddit' );
-		$sut   = $this->make_sut( $order->get_id(), false );
+		$order            = $this->create_order_with_attribution( 'reddit' );
+		$attribution_data = $this->create_testable_attribution_data( $order->get_id(), false );
 
-		$this->assertNull( $sut->get_order_attribution_source_for_edit_screen() );
+		$this->assertNull( $attribution_data->get_order_attribution_source_for_edit_screen() );
 	}
 }

--- a/tests/phpunit/Unit/Admin/MetaBox/OrderAttributionDataTest.php
+++ b/tests/phpunit/Unit/Admin/MetaBox/OrderAttributionDataTest.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Unit tests for OrderAttributionData.
+ *
+ * Note: test_hpos_path_returns_reddit and test_legacy_path_returns_reddit appear identical
+ * because get_order_id_from_request() is overridden in both. filter_input( INPUT_GET, ... )
+ * always returns null in CLI (PHPUnit), so the HPOS (?id=) vs legacy (?post=) URL-param
+ * branching inside that method cannot be exercised at unit-test level. The two cases are
+ * kept as separate tests to document intent against the acceptance criteria; full end-to-end
+ * coverage of both URL params requires an E2E or integration test.
+ *
+ * @package RedditForWooCommerce\Tests\Unit\Admin\MetaBox
+ */
+
+namespace RedditForWooCommerce\Tests\Unit\Admin\MetaBox;
+
+use WP_UnitTestCase;
+use RedditForWooCommerce\Admin\MetaBox\OrderAttributionData;
+
+/**
+ * @covers \RedditForWooCommerce\Admin\MetaBox\OrderAttributionData
+ */
+class OrderAttributionDataTest extends WP_UnitTestCase {
+
+	/**
+	 * Creates a real WC order with the given utm_source attribution meta.
+	 *
+	 * @param string $utm_source Value to store in _wc_order_attribution_utm_source.
+	 * @return \WC_Order
+	 */
+	private function create_order_with_attribution( string $utm_source ): \WC_Order {
+		$order = \WC_Helper_Order::create_order();
+		$order->update_meta_data( '_wc_order_attribution_utm_source', $utm_source );
+		$order->save();
+		return $order;
+	}
+
+	/**
+	 * Returns an anonymous subclass of OrderAttributionData with controlled screen and order ID.
+	 *
+	 * @param int  $mock_order_id Value returned by get_order_id_from_request().
+	 * @param bool $mock_screen   Value returned by is_wc_order_edit_screen().
+	 * @return OrderAttributionData
+	 */
+	private function make_sut( int $mock_order_id, bool $mock_screen ): OrderAttributionData {
+		return new class( $mock_order_id, $mock_screen ) extends OrderAttributionData {
+			private int $mock_order_id;
+			private bool $mock_screen;
+
+			public function __construct( int $mock_order_id, bool $mock_screen ) {
+				$this->mock_order_id = $mock_order_id;
+				$this->mock_screen   = $mock_screen;
+			}
+
+			public function is_wc_order_edit_screen(): bool {
+				return $this->mock_screen;
+			}
+
+			protected function get_order_id_from_request(): int {
+				return $this->mock_order_id;
+			}
+		};
+	}
+
+	/**
+	 * HPOS path: simulates the order ID arriving via the ?id= query parameter.
+	 */
+	public function test_hpos_path_returns_reddit(): void {
+		$order = $this->create_order_with_attribution( 'reddit' );
+		$sut   = $this->make_sut( $order->get_id(), true );
+
+		$this->assertSame( 'reddit', $sut->get_order_attribution_source_for_edit_screen() );
+	}
+
+	/**
+	 * Legacy path: simulates the order ID arriving via the ?post= query parameter.
+	 */
+	public function test_legacy_path_returns_reddit(): void {
+		$order = $this->create_order_with_attribution( 'reddit' );
+		$sut   = $this->make_sut( $order->get_id(), true );
+
+		$this->assertSame( 'reddit', $sut->get_order_attribution_source_for_edit_screen() );
+	}
+
+	/**
+	 * A non-reddit utm_source must return null.
+	 */
+	public function test_non_reddit_utm_source_returns_null(): void {
+		$order = $this->create_order_with_attribution( 'google' );
+		$sut   = $this->make_sut( $order->get_id(), true );
+
+		$this->assertNull( $sut->get_order_attribution_source_for_edit_screen() );
+	}
+
+	/**
+	 * No order ID in the request must return null even when on the correct screen.
+	 */
+	public function test_no_order_id_returns_null(): void {
+		$sut = $this->make_sut( 0, true );
+
+		$this->assertNull( $sut->get_order_attribution_source_for_edit_screen() );
+	}
+
+	/**
+	 * A valid reddit-attributed order must still return null when not on the edit order screen.
+	 */
+	public function test_wrong_screen_returns_null(): void {
+		$order = $this->create_order_with_attribution( 'reddit' );
+		$sut   = $this->make_sut( $order->get_id(), false );
+
+		$this->assertNull( $sut->get_order_attribution_source_for_edit_screen() );
+	}
+}

--- a/tests/phpunit/Unit/Admin/MetaBox/OrderAttributionDataTest.php
+++ b/tests/phpunit/Unit/Admin/MetaBox/OrderAttributionDataTest.php
@@ -66,7 +66,7 @@ class OrderAttributionDataTest extends WP_UnitTestCase {
 	 * HPOS path: simulates the order ID arriving via the ?id= query parameter.
 	 */
 	public function test_hpos_path_returns_reddit(): void {
-		$order            = $this->create_order_with_attribution( 'reddit' );
+		$order             = $this->create_order_with_attribution( 'reddit' );
 		$order_attribution = $this->create_order_attribution( $order->get_id(), true );
 
 		$this->assertSame( 'reddit', $order_attribution->get_order_attribution_source_for_edit_screen() );
@@ -76,7 +76,7 @@ class OrderAttributionDataTest extends WP_UnitTestCase {
 	 * Legacy path: simulates the order ID arriving via the ?post= query parameter.
 	 */
 	public function test_legacy_path_returns_reddit(): void {
-		$order            = $this->create_order_with_attribution( 'reddit' );
+		$order             = $this->create_order_with_attribution( 'reddit' );
 		$order_attribution = $this->create_order_attribution( $order->get_id(), true );
 
 		$this->assertSame( 'reddit', $order_attribution->get_order_attribution_source_for_edit_screen() );
@@ -86,7 +86,7 @@ class OrderAttributionDataTest extends WP_UnitTestCase {
 	 * A non-reddit utm_source must return null.
 	 */
 	public function test_non_reddit_utm_source_returns_null(): void {
-		$order            = $this->create_order_with_attribution( 'google' );
+		$order             = $this->create_order_with_attribution( 'google' );
 		$order_attribution = $this->create_order_attribution( $order->get_id(), true );
 
 		$this->assertNull( $order_attribution->get_order_attribution_source_for_edit_screen() );
@@ -105,7 +105,7 @@ class OrderAttributionDataTest extends WP_UnitTestCase {
 	 * A valid reddit-attributed order must still return null when not on the edit order screen.
 	 */
 	public function test_wrong_screen_returns_null(): void {
-		$order            = $this->create_order_with_attribution( 'reddit' );
+		$order             = $this->create_order_with_attribution( 'reddit' );
 		$order_attribution = $this->create_order_attribution( $order->get_id(), false );
 
 		$this->assertNull( $order_attribution->get_order_attribution_source_for_edit_screen() );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/REDTWOO-124/add-order-attribution-helpers-in-php

### Screenshots:

N/A


### Detailed test instructions:

1. Confirm the unit tests pass. Note there is no user-visible output in admin or elsewhere.


### Additional details:

> Add - Add order-attribution helpers in PHP