### PR TITLE
REDTWOO-126 Conditional Asset Enqueue and Inline Data on the Edit Product Screen

### DIFF
--- a/includes/Admin/MetaBox/ChannelVisibilityMetaBox.php
+++ b/includes/Admin/MetaBox/ChannelVisibilityMetaBox.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Channel visibility meta box (Edit Product) metadata keys.
+ *
+ * @package RedditForWooCommerce\Admin\MetaBox
+ * @since 0.1.0
+ */
+
+namespace RedditForWooCommerce\Admin\MetaBox;
+
+/**
+ * Constants for the Reddit channel visibility control on the product editor.
+ *
+ * @since 0.1.0
+ */
+final class ChannelVisibilityMetaBox {
+
+	/**
+	 * Meta key fragment (without plugin prefix) for catalog export eligibility.
+	 *
+	 * @since 0.1.0
+	 */
+	public const CATALOG_ITEM = 'product_catalog_item';
+}

--- a/includes/Admin/MetaBox/MetaBoxAssets.php
+++ b/includes/Admin/MetaBox/MetaBoxAssets.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Conditional admin assets for Reddit UI on the WooCommerce Edit Order screen.
+ * Conditional admin assets for Reddit UI on WooCommerce Edit Order and Edit Product screens.
  *
  * @package RedditForWooCommerce\Admin\MetaBox
  * @since 0.1.0
@@ -16,7 +16,7 @@ use RedditForWooCommerce\Utils\Storage\OptionDefaults;
 use RedditForWooCommerce\Utils\Storage\Options;
 
 /**
- * Enqueues the order-attribution bundle only on the WC order edit screen and inlines mount data.
+ * Enqueues meta box bundles only on matching WC admin screens and inlines mount data.
  *
  * @since 0.1.0
  */
@@ -34,40 +34,27 @@ class MetaBoxAssets {
 	}
 
 	/**
-	 * Loads order-attribution scripts and localize data as `redditAdsMetaBoxData`.
+	 * Loads order-attribution or channel-visibility scripts and localize data as `redditAdsMetaBoxData`.
+	 *
+	 * At most one bundle is enqueued per request.
 	 *
 	 * @since 0.1.0
 	 *
 	 * @return void
 	 */
 	public function enqueue_assets(): void {
-		if ( ! $this->should_enqueue_order_attribution_bundle() ) {
+		if ( $this->should_enqueue_order_attribution_bundle() ) {
+			$this->enqueue_order_attribution_assets();
 			return;
 		}
 
-		AssetLoader::enqueue_script( 'order-attribution', 'order-attribution' );
-
-		$urls = Helper::get_wc_admin_reddit_metabox_urls();
-
-		AssetLoader::localize_script(
-			'order-attribution',
-			'MetaBoxData',
-			array(
-				'slug'                   => Config::PLUGIN_SLUG,
-				'onboardingComplete'     => OnboardingStatus::is_setup_completed(),
-				'hasCampaign'            => ! empty( Options::get( OptionDefaults::CAMPAIGN_IDS ) ),
-				'orderAttributionSource' => OrderAttributionData::get_order_attribution_source(),
-				'urls'                   => array(
-					'start'          => $urls['start'],
-					'campaignCreate' => $urls['campaignCreate'],
-					'settings'       => $urls['settings'],
-				),
-			)
-		);
+		if ( ProductChannelVisibilityData::should_enqueue_channel_visibility_bundle() ) {
+			$this->enqueue_channel_visibility_assets();
+		}
 	}
 
 	/**
-	 * Gates the enqueue to the WooCommerce order edit screen.
+	 * Gates the order-attribution bundle to the WooCommerce order edit screen.
 	 *
 	 * @since 0.1.0
 	 *
@@ -75,5 +62,69 @@ class MetaBoxAssets {
 	 */
 	protected function should_enqueue_order_attribution_bundle(): bool {
 		return OrderAttributionData::is_wc_order_edit_screen();
+	}
+
+	/**
+	 * @return void
+	 */
+	private function enqueue_order_attribution_assets(): void {
+		AssetLoader::enqueue_script( 'order-attribution', 'order-attribution' );
+
+		$urls = Helper::get_wc_admin_reddit_metabox_urls();
+
+		AssetLoader::localize_script(
+			'order-attribution',
+			'MetaBoxData',
+			array_merge(
+				$this->get_shared_metabox_bootstrap(),
+				array(
+					'hasCampaign'            => ! empty( Options::get( OptionDefaults::CAMPAIGN_IDS ) ),
+					'orderAttributionSource' => OrderAttributionData::get_order_attribution_source(),
+					'urls'                   => array(
+						'start'          => $urls['start'],
+						'campaignCreate' => $urls['campaignCreate'],
+						'settings'       => $urls['settings'],
+					),
+				)
+			)
+		);
+	}
+
+	/**
+	 * @return void
+	 */
+	private function enqueue_channel_visibility_assets(): void {
+		$channel_visibility = ProductChannelVisibilityData::get_channel_visibility_inline_block();
+
+		if ( null === $channel_visibility ) {
+			return;
+		}
+
+		AssetLoader::enqueue_script( 'channel-visibility-meta-box', 'channel-visibility-meta-box' );
+
+		AssetLoader::localize_script(
+			'channel-visibility-meta-box',
+			'MetaBoxData',
+			array_merge(
+				$this->get_shared_metabox_bootstrap(),
+				array(
+					'channelVisibility' => $channel_visibility,
+				)
+			)
+		);
+	}
+
+	/**
+	 * Keys shared between order-attribution and channel-visibility localized payloads.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function get_shared_metabox_bootstrap(): array {
+		return array(
+			'slug'               => Config::PLUGIN_SLUG,
+			'onboardingComplete' => OnboardingStatus::is_setup_completed(),
+		);
 	}
 }

--- a/includes/Admin/MetaBox/MetaBoxAssets.php
+++ b/includes/Admin/MetaBox/MetaBoxAssets.php
@@ -65,6 +65,10 @@ class MetaBoxAssets {
 	}
 
 	/**
+	 * Enqueues the order-attribution bundle and passes localized data for the Edit Order screen.
+	 *
+	 * @since 0.1.0
+	 *
 	 * @return void
 	 */
 	private function enqueue_order_attribution_assets(): void {
@@ -91,6 +95,10 @@ class MetaBoxAssets {
 	}
 
 	/**
+	 * Enqueues the channel-visibility bundle and passes localized data for the Edit Product screen.
+	 *
+	 * @since 0.1.0
+	 *
 	 * @return void
 	 */
 	private function enqueue_channel_visibility_assets(): void {

--- a/includes/Admin/MetaBox/ProductChannelVisibilityData.php
+++ b/includes/Admin/MetaBox/ProductChannelVisibilityData.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Product edit screen detection and channel-visibility inline data for the meta box bundle.
+ *
+ * @package RedditForWooCommerce\Admin\MetaBox
+ * @since 0.1.0
+ */
+
+namespace RedditForWooCommerce\Admin\MetaBox;
+
+use RedditForWooCommerce\Utils\Helper;
+use WC_Product;
+
+/**
+ * Gates and payload for the Edit Product channel-visibility bundle (REDTWOO-126).
+ *
+ * Does not read cohabit/mode from PHP; those are resolved client-side at mount.
+ *
+ * @since 0.1.0
+ */
+final class ProductChannelVisibilityData {
+
+	/**
+	 * Whether to enqueue the channel-visibility bundle on this request.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @return bool
+	 */
+	public static function should_enqueue_channel_visibility_bundle(): bool {
+		return null !== self::get_channel_visibility_inline_block();
+	}
+
+	/**
+	 * Builds the `channelVisibility` object for `redditAdsMetaBoxData`.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @return array<string,mixed>|null Null when not on a valid product edit context.
+	 */
+	public static function get_channel_visibility_inline_block(): ?array {
+		if ( ! is_admin() ) {
+			return null;
+		}
+
+		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+
+		if ( null === $screen || 'product' !== $screen->id ) {
+			return null;
+		}
+
+		global $post;
+
+		if ( ! $post instanceof \WP_Post || 'product' !== $post->post_type ) {
+			return null;
+		}
+
+		$product = wc_get_product( $post->ID );
+
+		if ( ! $product instanceof WC_Product ) {
+			return null;
+		}
+
+		$field_name = Helper::with_prefix( ChannelVisibilityMetaBox::CATALOG_ITEM );
+		$raw_meta   = get_post_meta( $post->ID, $field_name, true );
+		$catalog    = is_string( $raw_meta ) && '' !== $raw_meta ? $raw_meta : '1';
+
+		return array(
+			'field_name'           => $field_name,
+			'product_catalog_item' => $catalog,
+			'product_is_visible'   => $product->is_visible(),
+			'options'              => array(
+				'1' => __( 'Sync and show', 'reddit-for-woocommerce' ),
+				'0' => __( "Don't sync and show", 'reddit-for-woocommerce' ),
+			),
+		);
+	}
+}

--- a/includes/Admin/ProductMeta/ProductMetaFields.php
+++ b/includes/Admin/ProductMeta/ProductMetaFields.php
@@ -11,6 +11,7 @@
 
 namespace RedditForWooCommerce\Admin\ProductMeta;
 
+use RedditForWooCommerce\Admin\MetaBox\ChannelVisibilityMetaBox;
 use RedditForWooCommerce\Utils\Helper;
 
 /**
@@ -36,7 +37,7 @@ class ProductMetaFields {
 	 *
 	 * @since 0.1.0
 	 */
-	public const CATALOG_ITEM = 'product_catalog_item';
+	public const CATALOG_ITEM = ChannelVisibilityMetaBox::CATALOG_ITEM;
 
 	/**
 	 * Registers all WooCommerce hooks.

--- a/js/src/meta-boxes/channel-visibility-meta-box/index.js
+++ b/js/src/meta-boxes/channel-visibility-meta-box/index.js
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+import domReady from '@wordpress/dom-ready';
+
+/**
+ * Reddit channel visibility / Edit Product screen bundle (REDTWOO-126 scaffolding).
+ */
+
+domReady( () => {
+	/* Mount point for channel visibility UI. */
+} );

--- a/tests/phpunit/Unit/Admin/MetaBox/MetaBoxAssetsTest.php
+++ b/tests/phpunit/Unit/Admin/MetaBox/MetaBoxAssetsTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests for conditional Edit Order meta box assets.
+ * Tests for conditional Edit Order and Edit Product meta box assets.
  *
  * @package RedditForWooCommerce\Tests\Unit\Admin\MetaBox
  */
@@ -9,6 +9,7 @@ namespace RedditForWooCommerce\Tests\Unit\Admin\MetaBox {
 
 use Automattic\WooCommerce\Internal\Admin\Orders\PageController;
 use Automattic\WooCommerce\Utilities\OrderUtil;
+use RedditForWooCommerce\Admin\MetaBox\ChannelVisibilityMetaBox;
 use RedditForWooCommerce\Admin\MetaBox\MetaBoxAssets;
 use RedditForWooCommerce\Admin\MetaBox\OrderAttributionData;
 use RedditForWooCommerce\Config;
@@ -22,26 +23,29 @@ use RedditForWooCommerce\Utils\Storage\Options;
  */
 final class MetaBoxAssetsTest extends WP_UnitTestCase {
 
-	private const SCRIPT_HANDLE = 'order-attribution';
+	private const SCRIPT_HANDLE_ORDER = 'order-attribution';
+
+	private const SCRIPT_HANDLE_CHANNEL = 'channel-visibility-meta-box';
 
 	public function set_up(): void {
 		parent::set_up();
 
 		wp_mkdir_p( REDDIT_FOR_WOOCOMMERCE_PLUGIN_BUILD_PATH );
 
-		$basename = self::SCRIPT_HANDLE;
+		foreach ( array( self::SCRIPT_HANDLE_ORDER, self::SCRIPT_HANDLE_CHANNEL ) as $basename ) {
+			file_put_contents( REDDIT_FOR_WOOCOMMERCE_PLUGIN_BUILD_PATH . $basename . '.js', '// test script' );
+			file_put_contents(
+				REDDIT_FOR_WOOCOMMERCE_PLUGIN_BUILD_PATH . $basename . '.js.asset.php',
+				'<?php return [ "dependencies" => [], "version" => "1.0.0" ];'
+			);
+		}
 
-		file_put_contents( REDDIT_FOR_WOOCOMMERCE_PLUGIN_BUILD_PATH . $basename . '.js', '// test script' );
-		file_put_contents(
-			REDDIT_FOR_WOOCOMMERCE_PLUGIN_BUILD_PATH . $basename . '.js.asset.php',
-			'<?php return [ "dependencies" => [], "version" => "1.0.0" ];'
-		);
-
-		wp_deregister_script( Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE );
+		wp_deregister_script( Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE_ORDER );
+		wp_deregister_script( Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE_CHANNEL );
 	}
 
 	public function tear_down(): void {
-		$this->cleanup_order_attribution_script();
+		$this->cleanup_metabox_build_scripts();
 		parent::tear_down();
 	}
 
@@ -52,13 +56,17 @@ final class MetaBoxAssetsTest extends WP_UnitTestCase {
 		$sut->enqueue_assets();
 
 		$this->assertFalse(
-			wp_script_is( Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE, 'enqueued' )
+			wp_script_is( Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE_ORDER, 'enqueued' )
+		);
+
+		$this->assertFalse(
+			wp_script_is( Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE_CHANNEL, 'enqueued' )
 		);
 
 		global $wp_scripts;
 
-		if ( isset( $wp_scripts->registered[ Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE ] ) ) {
-			$extra = $wp_scripts->registered[ Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE ]->extra;
+		if ( isset( $wp_scripts->registered[ Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE_ORDER ] ) ) {
+			$extra = $wp_scripts->registered[ Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE_ORDER ]->extra;
 			$this->assertArrayNotHasKey( 'data', is_array( $extra ) ? $extra : array() );
 		}
 	}
@@ -69,13 +77,17 @@ final class MetaBoxAssetsTest extends WP_UnitTestCase {
 
 		$sut->enqueue_assets();
 
+		$this->assertFalse(
+			wp_script_is( Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE_CHANNEL, 'enqueued' )
+		);
+
 		$this->assertTrue(
-			wp_script_is( Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE, 'enqueued' )
+			wp_script_is( Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE_ORDER, 'enqueued' )
 		);
 
 		global $wp_scripts;
 
-		$registered = $wp_scripts->registered[ Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE ] ?? null;
+		$registered = $wp_scripts->registered[ Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE_ORDER ] ?? null;
 		$this->assertNotNull( $registered );
 
 		$data_str = isset( $registered->extra['data'] ) ? (string) $registered->extra['data'] : ''; // phpcs:ignore Squiz.Commenting.InlineComment.InvalidEndChar
@@ -141,10 +153,11 @@ final class MetaBoxAssetsTest extends WP_UnitTestCase {
 		try {
 			$this->run_real_enqueue_in_admin_screen_context( array(), 'dashboard' );
 			$this->assertFalse(
-				wp_script_is( Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE, 'enqueued' ),
+				wp_script_is( Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE_ORDER, 'enqueued' ),
 				'Expected order-attribution absent on Dashboard.'
 			);
 			$this->assertFalse( OrderAttributionData::is_wc_order_edit_screen() );
+			$this->assert_channel_visibility_bundle_not_enqueued();
 		} finally {
 			$_GET = $get_backup;
 		}
@@ -156,25 +169,30 @@ final class MetaBoxAssetsTest extends WP_UnitTestCase {
 		try {
 			$this->run_real_enqueue_in_admin_screen_context( array(), 'plugins' );
 			$this->assertFalse(
-				wp_script_is( Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE, 'enqueued' ),
+				wp_script_is( Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE_ORDER, 'enqueued' ),
 				'Expected order-attribution absent on Plugins list.'
 			);
 			$this->assertFalse( OrderAttributionData::is_wc_order_edit_screen() );
+			$this->assert_channel_visibility_bundle_not_enqueued();
 		} finally {
 			$_GET = $get_backup;
 		}
 	}
 
-	public function test_real_metabox_not_enqueued_on_product_edit_screen(): void {
-		$get_backup       = $_GET;
-		$product_id       = self::factory()->post->create(
-			array(
-				'post_type'   => 'product',
-				'post_status' => 'publish',
-			)
-		);
+	public function test_real_channel_bundle_enqueued_on_product_edit_order_bundle_absent(): void {
+		$get_backup = $_GET;
+		global $post;
+		$post_backup = $post instanceof \WP_Post ? $post : null;
+
+		$wc_product = \WC_Helper_Product::create_simple_product();
+		$product_id = $wc_product->get_id();
+		$post_obj   = get_post( $product_id );
+		$this->assertNotNull( $post_obj );
 
 		try {
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			$post = $post_obj;
+
 			$this->run_real_enqueue_in_admin_screen_context(
 				array(
 					'post'   => (string) $product_id,
@@ -182,12 +200,146 @@ final class MetaBoxAssetsTest extends WP_UnitTestCase {
 				),
 				'product'
 			);
+
 			$this->assertFalse(
-				wp_script_is( Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE, 'enqueued' ),
+				wp_script_is( Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE_ORDER, 'enqueued' ),
 				'Expected order-attribution absent when editing a product.'
 			);
 			$this->assertFalse( OrderAttributionData::is_wc_order_edit_screen() );
+
+			$this->assertTrue(
+				wp_script_is( Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE_CHANNEL, 'enqueued' ),
+				'Expected channel-visibility-meta-box on product edit.'
+			);
+
+			$decoded = $this->decode_registered_metabox_payload( self::SCRIPT_HANDLE_CHANNEL );
+			$this->assertSame( Config::PLUGIN_SLUG, $decoded['slug'] ?? null );
+			$this->assertArrayHasKey( 'channelVisibility', $decoded );
+			$this->assertArrayNotHasKey( 'hasCampaign', $decoded );
+			$this->assertArrayNotHasKey( 'orderAttributionSource', $decoded );
+			$this->assertArrayNotHasKey( 'urls', $decoded );
+
+			$cv = $decoded['channelVisibility'];
+			$this->assertIsArray( $cv );
+			$this->assertSame( Helper::with_prefix( ChannelVisibilityMetaBox::CATALOG_ITEM ), $cv['field_name'] ?? null );
+			$this->assertSame( '1', $cv['product_catalog_item'] ?? null, 'Unset meta should default to catalog 1.' );
+			$this->assert_metabox_payload_bool( $cv['product_is_visible'] ?? null, true );
+			$this->assertSame( __( 'Sync and show', 'reddit-for-woocommerce' ), $cv['options']['1'] ?? null );
+			$this->assertSame( __( "Don't sync and show", 'reddit-for-woocommerce' ), $cv['options']['0'] ?? null );
+
+			$this->assertArrayNotHasKey( 'mode', $decoded );
+			$this->assertArrayNotHasKey( 'cohabit_target', $decoded );
+			$this->assertArrayNotHasKey( 'mode', $cv );
+			$this->assertArrayNotHasKey( 'cohabit_target', $cv );
 		} finally {
+			if ( $post_backup instanceof \WP_Post ) {
+				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+				$post = $post_backup;
+			} else {
+				unset( $GLOBALS['post'] );
+			}
+			$_GET = $get_backup;
+		}
+	}
+
+	public function test_real_channel_bundle_not_enqueued_on_product_screen_without_global_post(): void {
+		$get_backup = $_GET;
+		global $post;
+		$post_backup = $post instanceof \WP_Post ? $post : null;
+
+		$wc_product = \WC_Helper_Product::create_simple_product();
+
+		try {
+			unset( $GLOBALS['post'] );
+
+			$this->run_real_enqueue_in_admin_screen_context(
+				array(
+					'post'   => (string) $wc_product->get_id(),
+					'action' => 'edit',
+				),
+				'product'
+			);
+
+			$this->assert_channel_visibility_bundle_not_enqueued();
+		} finally {
+			if ( $post_backup instanceof \WP_Post ) {
+				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+				$post = $post_backup;
+			} else {
+				unset( $GLOBALS['post'] );
+			}
+			$_GET = $get_backup;
+		}
+	}
+
+	public function test_real_product_channel_payload_respects_catalog_meta_zero(): void {
+		$get_backup = $_GET;
+		global $post;
+		$post_backup = $post instanceof \WP_Post ? $post : null;
+
+		$wc_product = \WC_Helper_Product::create_simple_product();
+		$field      = Helper::with_prefix( ChannelVisibilityMetaBox::CATALOG_ITEM );
+		update_post_meta( $wc_product->get_id(), $field, '0' );
+		$post_obj = get_post( $wc_product->get_id() );
+		$this->assertNotNull( $post_obj );
+
+		try {
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			$post = $post_obj;
+
+			$this->run_real_enqueue_in_admin_screen_context(
+				array(
+					'post'   => (string) $wc_product->get_id(),
+					'action' => 'edit',
+				),
+				'product'
+			);
+
+			$decoded = $this->decode_registered_metabox_payload( self::SCRIPT_HANDLE_CHANNEL );
+			$this->assertSame( '0', $decoded['channelVisibility']['product_catalog_item'] ?? null );
+		} finally {
+			if ( $post_backup instanceof \WP_Post ) {
+				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+				$post = $post_backup;
+			} else {
+				unset( $GLOBALS['post'] );
+			}
+			$_GET = $get_backup;
+		}
+	}
+
+	public function test_real_product_channel_payload_reflects_non_visible_product(): void {
+		$get_backup = $_GET;
+		global $post;
+		$post_backup = $post instanceof \WP_Post ? $post : null;
+
+		$wc_product = \WC_Helper_Product::create_simple_product();
+		$wc_product->set_catalog_visibility( 'hidden' );
+		$wc_product->save();
+		$post_obj = get_post( $wc_product->get_id() );
+		$this->assertNotNull( $post_obj );
+
+		try {
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			$post = $post_obj;
+
+			$this->run_real_enqueue_in_admin_screen_context(
+				array(
+					'post'   => (string) $wc_product->get_id(),
+					'action' => 'edit',
+				),
+				'product'
+			);
+
+			$decoded = $this->decode_registered_metabox_payload( self::SCRIPT_HANDLE_CHANNEL );
+			$this->assert_metabox_payload_bool( $decoded['channelVisibility']['product_is_visible'] ?? null, false );
+		} finally {
+			if ( $post_backup instanceof \WP_Post ) {
+				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+				$post = $post_backup;
+			} else {
+				unset( $GLOBALS['post'] );
+			}
 			$_GET = $get_backup;
 		}
 	}
@@ -203,10 +355,11 @@ final class MetaBoxAssetsTest extends WP_UnitTestCase {
 				'woocommerce_page_wc-admin'
 			);
 			$this->assertFalse(
-				wp_script_is( Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE, 'enqueued' ),
+				wp_script_is( Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE_ORDER, 'enqueued' ),
 				'Expected order-attribution absent on wc-admin.'
 			);
 			$this->assertFalse( OrderAttributionData::is_wc_order_edit_screen() );
+			$this->assert_channel_visibility_bundle_not_enqueued();
 		} finally {
 			$_GET = $get_backup;
 		}
@@ -218,15 +371,16 @@ final class MetaBoxAssetsTest extends WP_UnitTestCase {
 		try {
 			$this->run_real_enqueue_in_admin_screen_context( array(), 'options-general' );
 			$this->assertFalse(
-				wp_script_is( Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE, 'enqueued' ),
+				wp_script_is( Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE_ORDER, 'enqueued' ),
 				'Expected order-attribution absent on Settings > General.'
 			);
 			$this->assertFalse( OrderAttributionData::is_wc_order_edit_screen() );
 			$this->assertNotContains(
-				Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE,
+				Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE_ORDER,
 				wp_scripts()->queue,
 				'wp_scripts()->queue should not list order-attribution on core Settings.'
 			);
+			$this->assert_channel_visibility_bundle_not_enqueued();
 		} finally {
 			$_GET = $get_backup;
 		}
@@ -243,15 +397,16 @@ final class MetaBoxAssetsTest extends WP_UnitTestCase {
 				'woocommerce_page_wc-settings'
 			);
 			$this->assertFalse(
-				wp_script_is( Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE, 'enqueued' ),
+				wp_script_is( Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE_ORDER, 'enqueued' ),
 				'Expected order-attribution absent on WooCommerce > Settings.'
 			);
 			$this->assertFalse( OrderAttributionData::is_wc_order_edit_screen() );
 			$this->assertNotContains(
-				Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE,
+				Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE_ORDER,
 				wp_scripts()->queue,
 				'wp_scripts()->queue should not list order-attribution on WooCommerce settings.'
 			);
+			$this->assert_channel_visibility_bundle_not_enqueued();
 		} finally {
 			$_GET = $get_backup;
 		}
@@ -276,14 +431,15 @@ final class MetaBoxAssetsTest extends WP_UnitTestCase {
 				'Order edit helper should delegate to WooCommerce OrderUtil.'
 			);
 			$this->assertTrue(
-				wp_script_is( Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE, 'enqueued' ),
+				wp_script_is( Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE_ORDER, 'enqueued' ),
 				'Expected order-attribution on legacy Edit Order screen.'
 			);
 			$this->assertContains(
-				Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE,
+				Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE_ORDER,
 				wp_scripts()->queue,
 				'wp_scripts()->queue should list order-attribution on legacy Edit Order.'
 			);
+			$this->assert_channel_visibility_bundle_not_enqueued();
 		} finally {
 			unset( $GLOBALS['reddit_for_woocommerce_tests_filter_input_get_post_id'] );
 			$_GET = $get_backup;
@@ -307,7 +463,7 @@ final class MetaBoxAssetsTest extends WP_UnitTestCase {
 			self::ensure_admin_request_context_for_tests();
 
 			wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
-			$this->purge_order_attribution_script_state();
+			$this->purge_metabox_script_registration_state();
 
 			// phpcs:disable WordPress.WP.GlobalVariablesOverride.Prohibited -- Mirrors WooCommerce PageControllerTest HPOS bootstrap.
 			$pagenow     = 'admin.php';
@@ -334,14 +490,15 @@ final class MetaBoxAssetsTest extends WP_UnitTestCase {
 				'Order edit screen helper should be true after PageController::setup() on HPOS edit URL.'
 			);
 			$this->assertTrue(
-				wp_script_is( Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE, 'enqueued' ),
+				wp_script_is( Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE_ORDER, 'enqueued' ),
 				'Expected order-attribution on HPOS Edit Order screen.'
 			);
 			$this->assertContains(
-				Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE,
+				Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE_ORDER,
 				wp_scripts()->queue,
 				'wp_scripts()->queue should list order-attribution on HPOS Edit Order.'
 			);
+			$this->assert_channel_visibility_bundle_not_enqueued();
 		} finally {
 			if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
 				// phpcs:disable WordPress.WP.GlobalVariablesOverride.Prohibited
@@ -384,7 +541,7 @@ final class MetaBoxAssetsTest extends WP_UnitTestCase {
 
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
 
-		$this->purge_order_attribution_script_state();
+		$this->purge_metabox_script_registration_state();
 
 		$_GET = array(
 			'post'   => (string) $order_id,
@@ -448,7 +605,7 @@ final class MetaBoxAssetsTest extends WP_UnitTestCase {
 
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
 
-		$this->purge_order_attribution_script_state();
+		$this->purge_metabox_script_registration_state();
 
 		$_GET = $get;
 
@@ -473,10 +630,12 @@ final class MetaBoxAssetsTest extends WP_UnitTestCase {
 	/**
 	 * @return void
 	 */
-	private function purge_order_attribution_script_state(): void {
-		$prefixed_handle = Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE;
-		wp_dequeue_script( $prefixed_handle );
-		wp_deregister_script( $prefixed_handle );
+	private function purge_metabox_script_registration_state(): void {
+		foreach ( array( self::SCRIPT_HANDLE_ORDER, self::SCRIPT_HANDLE_CHANNEL ) as $basename ) {
+			$prefixed_handle = Config::ASSET_HANDLE_PREFIX . $basename;
+			wp_dequeue_script( $prefixed_handle );
+			wp_deregister_script( $prefixed_handle );
+		}
 	}
 
 	/**
@@ -490,21 +649,27 @@ final class MetaBoxAssetsTest extends WP_UnitTestCase {
 		require_once ABSPATH . 'wp-admin/includes/screen.php';
 	}
 
-	private function cleanup_order_attribution_script(): void {
-		$prefixed_handle = Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE;
-		wp_dequeue_script( $prefixed_handle );
-		wp_deregister_script( $prefixed_handle );
-		@unlink( REDDIT_FOR_WOOCOMMERCE_PLUGIN_BUILD_PATH . self::SCRIPT_HANDLE . '.js' ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
-		@unlink( REDDIT_FOR_WOOCOMMERCE_PLUGIN_BUILD_PATH . self::SCRIPT_HANDLE . '.js.asset.php' ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+	/**
+	 * @return void
+	 */
+	private function cleanup_metabox_build_scripts(): void {
+		foreach ( array( self::SCRIPT_HANDLE_ORDER, self::SCRIPT_HANDLE_CHANNEL ) as $basename ) {
+			$prefixed_handle = Config::ASSET_HANDLE_PREFIX . $basename;
+			wp_dequeue_script( $prefixed_handle );
+			wp_deregister_script( $prefixed_handle );
+			@unlink( REDDIT_FOR_WOOCOMMERCE_PLUGIN_BUILD_PATH . $basename . '.js' ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+			@unlink( REDDIT_FOR_WOOCOMMERCE_PLUGIN_BUILD_PATH . $basename . '.js.asset.php' ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		}
 	}
 
 	/**
+	 * @param string $script_basename Unprefixed script basename (e.g. order-attribution).
 	 * @return array<mixed,mixed>
 	 */
-	private function decode_registered_metabox_payload(): array {
+	private function decode_registered_metabox_payload( string $script_basename = self::SCRIPT_HANDLE_ORDER ): array {
 		global $wp_scripts;
 
-		$handle     = Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE;
+		$handle     = Config::ASSET_HANDLE_PREFIX . $script_basename;
 		$registered = $wp_scripts->registered[ $handle ] ?? null;
 
 		$this->assertNotNull( $registered );
@@ -527,6 +692,16 @@ final class MetaBoxAssetsTest extends WP_UnitTestCase {
 		}
 
 		return $decoded;
+	}
+
+	/**
+	 * @return void
+	 */
+	private function assert_channel_visibility_bundle_not_enqueued(): void {
+		$this->assertFalse(
+			wp_script_is( Config::ASSET_HANDLE_PREFIX . self::SCRIPT_HANDLE_CHANNEL, 'enqueued' ),
+			'Expected channel-visibility-meta-box absent on this screen.'
+		);
 	}
 
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -90,6 +90,11 @@ const webpackConfig = {
 			'js/src/meta-boxes/order-attribution',
 			'index.js'
 		),
+		'channel-visibility-meta-box': path.resolve(
+			process.cwd(),
+			'js/src/meta-boxes/channel-visibility-meta-box',
+			'index.js'
+		),
 	} ),
 	output: {
 		...defaultConfig.output,


### PR DESCRIPTION
### Changes proposed in this Pull Request:
I've branched off of `feature/REDTWOO-125-conditional-asset-enqueue-inline-data-on-the-edit-order-screen` since both of these share some common grounds. So after approval this can be merged into that branch and finally both of **REDTWOO-125** and **REDTWOO-126** can be merged into the target branch `feature/reddit-in-product-placements`

This work extends the existing Edit Order meta box asset pattern so the Edit Product screen loads a dedicated channel-visibility-meta-box bundle only when appropriate, and passes mount data through the same global name as orders: `window.redditAdsMetaBoxData` (via MetaBoxData + the plugin’s JS var prefix). At most one of order-attribution or channel-visibility-meta-box is enqueued per request.

**What changed**
MetaBoxAssets — After the order-edit branch, if the request is a valid product edit context (`WP_Screen::id === 'product' `plus a real product post / `wc_get_product`), enqueues channel-visibility-meta-box and localizes slug, onboardingComplete, and channelVisibility (no mode / cohabit_target; those stay client-side per spec).

ProductChannelVisibilityData — Centralizes screen/product checks and builds `channelVisibility: field_name` (prefixed catalog meta key), `product_catalog_item` (defaults to '1' when meta is empty, matching the PHP panel), `product_is_visible`, and translatable options for '1' / '0'.

ChannelVisibilityMetaBox — Holds `CATALOG_ITEM`; `ProductMetaFields::CATALOG_ITEM` is pointed at it so the meta key stays single-sourced.

Webpack — New entry `channel-visibility-meta-box → js/src/meta-boxes/channel-visibility-meta-box/index.js` (minimal domReady scaffold for follow-up UI).

Tests — MetaBoxAssetsTest covers product enqueue + payload shape, absence of order-only keys, no cohabit/mode keys, negative screens (dashboard, orders, etc.), and that the channel bundle is not loaded alongside the order bundle.

Closes https://linear.app/a8c/issue/REDTWOO-126/conditional-asset-enqueue-inline-data-on-the-edit-product-screen

### Detailed test instructions:
**A. Edit Product**
1. Open Products → All Products → pick any product → Edit (the classic product data screen, not a random admin page).
2. Open devtools → Network, filter by JS (or search for channel-visibility). Reload the page.
3. You should see the channel-visibility-meta-box script load (handle will be prefixed by the plugin’s asset prefix in the HTML—what matters is that filename/handle pattern, not the exact string).
4. In View page source (or the script tag / localized data block), find redditAdsMetaBoxData. Skim it: you want slug, onboardingComplete, and a channelVisibility object with field_name, product_catalog_item, product_is_visible, and options for 1 and 0. You should not see order-only stuff like urls, hasCampaign, or orderAttributionSource on this screen.

**B. Edit Order** (just sanity's sake that we didn’t bleed product JS into orders)
Open WooCommerce → Orders → open an order → edit screen (HPOS or legacy, whichever you use).
Same network check: you should see order-attribution, not the channel-visibility bundle.
redditAdsMetaBoxData here should still look like the order payload (e.g. urls, hasCampaign, orderAttributionSource, etc.), not the product channelVisibility block.

**C. Other Screens**
Hit a couple of admin pages where we should load neither bundle—Dashboard, Plugins, or WooCommerce → Settings. Reload with network open: neither meta-box script should show up.

### Additional details:

Conditional asset enqueue and inline data on the edit product screen