### PR TITLE
REDTWOO-137 Add e2e tests for channel visibility meta box

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -2,6 +2,7 @@
 	"phpVersion": null,
 	"core": null,
 	"plugins": [
+		"https://github.com/WP-API/Basic-Auth/archive/master.zip",
 		"https://downloads.wordpress.org/plugin/woocommerce.zip",
 		".",
 		"./tests/e2e/plugins/reddit-options.php"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,11 +106,20 @@ npm run lint:css        # Stylelint
 
 ### Unit Tests
 
+**First-time setup:**
+
+1. Install Node and Composer dependencies: `npm install && composer install`
+2. Start the containers: `npm run env:start`
+3. Run the one-time PHPUnit setup: `npm run test:unit:wp-env:setup`
+4. Run the tests: `npm run test:unit:wp-env`
+
+**Subsequent runs** (containers already up):
+
 ```bash
-npm run env:start                   # Start wp-env containers
-npm run test:unit:wp-env:setup      # One-time setup after containers start
-npm run test:unit:wp-env            # Run PHPUnit via wp-env (latest WP, nightly WC)
+npm run test:unit:wp-env
 ```
+
+> **Note:** `npm run build` strips dev dependencies (`composer install --no-dev`). Run `composer install` again before running tests after a production build.
 
 Tests are in `tests/phpunit/Unit/` and follow the namespace structure of `includes/`.
 
@@ -126,6 +135,23 @@ npm run env:destroy     # Tear down containers
 - E2E tests use **Playwright** (not Codeception).
 - Test specs are in `tests/e2e/specs/`.
 - A test helper mu-plugin (`tests/e2e/plugins/reddit-options.php`) pre-configures plugin options for the test environment.
+
+**First-time setup:**
+
+```bash
+npx playwright install chromium   # Install browser (once)
+npm run env:start                 # Start containers and run initialize.sh
+npm run test:e2e                  # Run all E2E tests
+```
+
+**Subsequent runs** (containers already up):
+
+```bash
+npm run test:e2e                             # All tests
+npm run test:e2e -- --grep "Channel Visibility"  # Single suite
+```
+
+> **Note:** `npm run env:start` re-runs `initialize.sh` on every start, creating duplicate seed products if run more than once. If the shop ends up with duplicates, run `npm run env:destroy && npm run env:start` to reset.
 
 ### Other
 

--- a/includes/Admin/MetaBox/MetaBoxAssets.php
+++ b/includes/Admin/MetaBox/MetaBoxAssets.php
@@ -30,7 +30,30 @@ class MetaBoxAssets {
 	 * @return void
 	 */
 	public function register_hooks(): void {
+		add_action( 'add_meta_boxes_product', array( $this, 'register_channel_visibility_meta_box' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+	}
+
+	/**
+	 * Registers the Channel Visibility meta box on the product edit screen.
+	 *
+	 * WooCommerce no longer provides this meta box in recent versions, so the
+	 * plugin registers it directly. The JS bundle mounts the React component
+	 * into the `.inside` wrapper that WordPress generates for every meta box.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @return void
+	 */
+	public function register_channel_visibility_meta_box(): void {
+		add_meta_box(
+			'channel_visibility',
+			__( 'Channel visibility', 'reddit-for-woocommerce' ),
+			'__return_empty_string',
+			'product',
+			'side',
+			'default'
+		);
 	}
 
 	/**

--- a/includes/Admin/ProductMeta/ProductMetaFields.php
+++ b/includes/Admin/ProductMeta/ProductMetaFields.php
@@ -81,42 +81,25 @@ class ProductMetaFields {
 	/**
 	 * Renders the Reddit product data panel.
 	 *
-	 * Displays a checkbox allowing the merchant to mark the product as eligible
-	 * for inclusion in the Reddit product catalog.
+	 * The catalog-item value is managed by the channel-visibility sidebar select
+	 * control (ChannelVisibilitySettings), which posts the same meta key. This
+	 * panel exists solely to register the "Reddit" tab in the product data tabs.
 	 *
 	 * @since 0.1.0
 	 * @return void
 	 */
 	public function render_panel(): void {
-		global $post;
-
-		$meta_key = Helper::with_prefix( self::CATALOG_ITEM );
-		$value    = get_post_meta( $post->ID, $meta_key, true );
-
-		if ( '' === $value ) {
-			$value = '1';
-		}
-
 		?>
-		<div id="reddit_product_data" class="panel woocommerce_options_panel hidden">
-			<p class="form-field">
-				<label for="<?php echo esc_attr( $meta_key ); ?>">
-					<?php esc_html_e( 'Catalog Item', 'reddit-for-woocommerce' ); ?>
-				</label>
-				<input type="checkbox"
-					name="<?php echo esc_attr( $meta_key ); ?>"
-					id="<?php echo esc_attr( $meta_key ); ?>"
-					value="1" <?php checked( $value, '1' ); ?> />
-				<span class="description">
-					<?php esc_html_e( "Include this product in Reddit's product catalog.", 'reddit-for-woocommerce' ); ?>
-				</span>
-			</p>
-		</div>
+		<div id="reddit_product_data" class="panel woocommerce_options_panel hidden"></div>
 		<?php
 	}
 
 	/**
 	 * Saves the Reddit exportable flag when the product is saved.
+	 *
+	 * The value is posted by the channel-visibility sidebar SelectControl. When
+	 * the select is not rendered (e.g. promo banner is shown instead), the field
+	 * is absent from POST and the existing meta value is preserved.
 	 *
 	 * @since 0.1.0
 	 *
@@ -128,8 +111,12 @@ class ProductMetaFields {
 
 		// Nonce verification done in the Woo Core parent method.
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing
-		$enabled = isset( $_POST[ $meta_key ] ) && '1' === $_POST[ $meta_key ];
+		if ( ! isset( $_POST[ $meta_key ] ) ) {
+			return;
+		}
 
-		update_post_meta( $post_id, $meta_key, $enabled ? '1' : '0' );
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$value = '0' === $_POST[ $meta_key ] ? '0' : '1';
+		update_post_meta( $post_id, $meta_key, $value );
 	}
 }

--- a/tests/e2e/bin/initialize.sh
+++ b/tests/e2e/bin/initialize.sh
@@ -13,6 +13,10 @@ wp-env run tests-cli wp plugin list
 wp-env run tests-cli wp theme activate storefront
 wp-env run tests-cli wp option update storefront_nux_dismissed 1
 
+# Disable the block product editor so the classic editor is used in E2E tests.
+# The channel visibility meta box only renders in the classic editor.
+wp-env run tests-cli wp option update woocommerce_feature_product_block_editor_enabled no
+
 # Activate and setup WooCommerce.
 wp-env run tests-cli wp wc tool run install_pages --user=1
 

--- a/tests/e2e/config/default.json
+++ b/tests/e2e/config/default.json
@@ -1,0 +1,39 @@
+{
+	"url": "http://localhost:8889/",
+	"users": {
+		"admin": {
+			"username": "admin",
+			"password": "password"
+		},
+		"customer": {
+			"username": "customer",
+			"password": "password"
+		}
+	},
+	"products": {
+		"simple": {
+			"name": "E2E Test Product",
+			"type": "simple",
+			"regular_price": "9.99",
+			"status": "publish"
+		}
+	},
+	"addresses": {
+		"customer": {
+			"billing": {
+				"firstname": "John",
+				"lastname": "Doe",
+				"company": "Automattic",
+				"country": "United States (US)",
+				"addressfirstline": "addr 1",
+				"addresssecondline": "addr 2",
+				"city": "San Francisco",
+				"state": "CA",
+				"statename": "California",
+				"postcode": "94107",
+				"phone": "123456789",
+				"email": "john.doe@example.com"
+			}
+		}
+	}
+}

--- a/tests/e2e/config/index.js
+++ b/tests/e2e/config/index.js
@@ -1,25 +1,24 @@
-const admin = {
-	username: 'admin',
-	password: 'password',
-};
+const config = require( './default.json' );
+const { billing } = config.addresses.customer;
+
+const admin = config.users.admin;
 
 const customer = {
-	username: 'customer',
-	password: 'password',
+	...config.users.customer,
 	billing: {
-		firstName: 'John',
-		lastName: 'Doe',
-		company: 'Automattic',
+		firstName: billing.firstname,
+		lastName: billing.lastname,
+		company: billing.company,
 		country: 'US',
 		countryName: 'United States',
-		address: 'addr 1',
-		addressSecondLine: 'addr 2',
-		city: 'San Francisco',
-		state: 'CA',
-		stateName: 'California',
-		zip: '94107',
-		phone: '123456789',
-		email: 'john.doe@example.com',
+		address: billing.addressfirstline,
+		addressSecondLine: billing.addresssecondline,
+		city: billing.city,
+		state: billing.state,
+		stateName: billing.statename,
+		zip: billing.postcode,
+		phone: billing.phone,
+		email: billing.email,
 	},
 };
 

--- a/tests/e2e/plugins/reddit-options.php
+++ b/tests/e2e/plugins/reddit-options.php
@@ -17,24 +17,52 @@ if ( class_exists( Options::class ) && defined( 'E2E_CONTEXT' ) ) {
 }
 
 /**
- * Registers a REST API endpoint to switch the current WordPress theme.
- * This is used in E2E tests to toggle between classic and block themes.
+ * Registers REST API endpoints used in E2E tests.
  *
- * Route: POST /wp-json/reddit-e2e/v1/switch-theme
- * Body:  { "theme": "twentytwentyfour" }
+ * Routes:
+ *   POST   /wp-json/reddit-e2e/v1/switch-theme          { "theme": "twentytwentyfour" }
+ *   POST   /wp-json/reddit-e2e/v1/onboarding-status     { "status": "connected" }
+ *   DELETE /wp-json/reddit-e2e/v1/onboarding-status
  */
 add_action( 'rest_api_init', function () {
-	register_rest_route( 'reddit-e2e/v1', '/switch-theme', array(
-		'methods'             => 'POST',
-		'callback'            => 'reddit_e2e_switch_theme_callback',
-		'permission_callback' => '__return_true',
-		'args'                => array(
-			'theme' => array(
-				'type'     => 'string',
-				'required' => true,
+	register_rest_route(
+		'reddit-e2e/v1',
+		'/switch-theme',
+		array(
+			'methods'             => 'POST',
+			'callback'            => 'reddit_e2e_switch_theme_callback',
+			'permission_callback' => '__return_true',
+			'args'                => array(
+				'theme' => array(
+					'type'     => 'string',
+					'required' => true,
+				),
 			),
-		),
-	) );
+		)
+	);
+
+	register_rest_route(
+		'reddit-e2e/v1',
+		'/onboarding-status',
+		array(
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => 'reddit_e2e_set_onboarding_status_callback',
+				'permission_callback' => '__return_true',
+				'args'                => array(
+					'status' => array(
+						'type'     => 'string',
+						'required' => true,
+					),
+				),
+			),
+			array(
+				'methods'             => WP_REST_Server::DELETABLE,
+				'callback'            => 'reddit_e2e_clear_onboarding_status_callback',
+				'permission_callback' => '__return_true',
+			),
+		)
+	);
 } );
 
 /**
@@ -45,23 +73,42 @@ add_action( 'rest_api_init', function () {
  */
 function reddit_e2e_switch_theme_callback( WP_REST_Request $request ) {
 	if ( ! defined( 'E2E_CONTEXT' ) || ! E2E_CONTEXT ) {
-		return new WP_REST_Response( array(
-			'error' => 'Endpoint only allowed in E2E context.',
-		), 403 );
+		return new WP_REST_Response( array( 'error' => 'Endpoint only allowed in E2E context.' ), 403 );
 	}
 
 	$theme_slug = $request->get_param( 'theme' );
 
 	if ( ! wp_get_theme( $theme_slug )->exists() ) {
-		return new WP_REST_Response( array(
-			'error' => "Theme '$theme_slug' does not exist.",
-		), 400 );
+		return new WP_REST_Response( array( 'error' => "Theme '$theme_slug' does not exist." ), 400 );
 	}
 
 	switch_theme( $theme_slug );
 
-	return new WP_REST_Response( array(
-		'success' => true,
-		'message' => "Theme switched to '$theme_slug'.",
-	) );
+	return new WP_REST_Response(
+		array(
+			'success' => true,
+			'message' => "Theme switched to '$theme_slug'.",
+		)
+	);
+}
+
+/**
+ * Sets the Reddit onboarding status option.
+ *
+ * @param WP_REST_Request $request REST request object.
+ * @return WP_REST_Response
+ */
+function reddit_e2e_set_onboarding_status_callback( WP_REST_Request $request ) {
+	update_option( 'reddit_onboarding_status', $request->get_param( 'status' ) );
+	return new WP_REST_Response( array( 'success' => true ), 200 );
+}
+
+/**
+ * Clears the Reddit onboarding status option.
+ *
+ * @return WP_REST_Response
+ */
+function reddit_e2e_clear_onboarding_status_callback() {
+	delete_option( 'reddit_onboarding_status' );
+	return new WP_REST_Response( array( 'success' => true ), 200 );
 }

--- a/tests/e2e/specs/meta-boxes/channel-visibility-meta-box.test.js
+++ b/tests/e2e/specs/meta-boxes/channel-visibility-meta-box.test.js
@@ -1,0 +1,253 @@
+/**
+ * External dependencies
+ */
+const { test, expect } = require( '@playwright/test' );
+
+/**
+ * Internal dependencies
+ */
+import {
+	createSimpleProduct,
+	deleteProduct,
+	setPromoDismissed,
+	setOnboardingComplete,
+} from '../../utils/api';
+import { getClassicProductEditorUtils } from '../../utils/product-editor';
+
+test.use( { storageState: process.env.ADMINSTATE } );
+
+test.describe.configure( { mode: 'serial' } );
+
+const GET_STARTED_URL_PATTERN = /page=wc-admin&path=%2Freddit%2Fstart/;
+
+/**
+ * @type {import('@playwright/test').Page}
+ */
+let page = null;
+
+/**
+ * @type {ReturnType<typeof getClassicProductEditorUtils>}
+ */
+let editorUtils = null;
+
+test.describe( 'Channel Visibility Meta Box', () => {
+	let productId = null;
+
+	test.beforeAll( async ( { browser } ) => {
+		page = await browser.newPage( {
+			storageState: process.env.ADMINSTATE,
+		} );
+		editorUtils = getClassicProductEditorUtils( page );
+		productId = await createSimpleProduct();
+	} );
+
+	test.afterAll( async () => {
+		await deleteProduct( productId );
+		await page.close();
+	} );
+
+	test.describe( 'Onboarding not completed', () => {
+		test.beforeEach( async () => {
+			await setOnboardingComplete( false );
+		} );
+
+		test( 'Shows full promo banner when not dismissed', async () => {
+			await setPromoDismissed( false );
+			await editorUtils.gotoEditProductPage( productId );
+
+			const rfwBox = editorUtils.getChannelVisibilityMetaBox();
+
+			await expect(
+				rfwBox.getByRole( 'heading', {
+					level: 3,
+					name: 'Get your products on Reddit',
+				} )
+			).toBeVisible();
+
+			await expect(
+				rfwBox.getByText( /Sync your catalog to reach shoppers/ )
+			).toBeVisible();
+
+			const getStartedLink = rfwBox.getByRole( 'link', {
+				name: 'Get started',
+			} );
+			await expect( getStartedLink ).toBeVisible();
+			await expect( getStartedLink ).toHaveAttribute(
+				'href',
+				GET_STARTED_URL_PATTERN
+			);
+
+			await expect(
+				rfwBox.getByRole( 'button', { name: 'Dismiss' } )
+			).toBeVisible();
+
+			await expect(
+				rfwBox.locator(
+					'.rfw-channel-visibility__get-started--is-dismissed'
+				)
+			).toBeHidden();
+		} );
+
+		test( 'Shows compact header with Get started only when dismissed', async () => {
+			await setPromoDismissed( true );
+			await editorUtils.gotoEditProductPage( productId );
+
+			const rfwBox = editorUtils.getChannelVisibilityMetaBox();
+
+			const compactGetStarted = rfwBox
+				.locator( '.rfw-channel-visibility__get-started--is-dismissed' )
+				.getByRole( 'link', { name: 'Get started' } );
+
+			await expect( compactGetStarted ).toBeVisible();
+			await expect( compactGetStarted ).toHaveAttribute(
+				'href',
+				GET_STARTED_URL_PATTERN
+			);
+
+			await expect(
+				editorUtils.getChannelVisibilityMetaBoxContent()
+			).toBeHidden();
+
+			await expect(
+				rfwBox.getByRole( 'button', { name: 'Dismiss' } )
+			).toBeHidden();
+
+			await expect(
+				rfwBox.getByText( 'Get your products on Reddit' )
+			).toBeHidden();
+		} );
+
+		test( 'Clicking on dismiss shows compact layout and settings are persisted on page refresh', async () => {
+			await setPromoDismissed( false );
+			await editorUtils.gotoEditProductPage( productId );
+
+			const rfwBox = editorUtils.getChannelVisibilityMetaBox();
+
+			await expect(
+				editorUtils.getChannelVisibilityMetaBoxContent()
+			).toBeVisible();
+
+			await rfwBox.getByRole( 'button', { name: 'Dismiss' } ).click();
+
+			await expect(
+				editorUtils.getChannelVisibilityMetaBoxContent()
+			).toBeHidden();
+
+			await editorUtils.gotoEditProductPage( productId );
+
+			const rfwBoxAfterRefresh =
+				editorUtils.getChannelVisibilityMetaBox();
+
+			await expect(
+				rfwBoxAfterRefresh.locator(
+					'.rfw-channel-visibility__get-started--is-dismissed'
+				)
+			).toBeVisible();
+
+			await expect(
+				rfwBoxAfterRefresh.getByRole( 'button', { name: 'Dismiss' } )
+			).toBeHidden();
+		} );
+	} );
+
+	test.describe( 'Onboarding completed', () => {
+		test.beforeAll( async () => {
+			await setOnboardingComplete( true );
+		} );
+
+		test.afterAll( async () => {
+			await setOnboardingComplete( false );
+		} );
+
+		test( 'Shows channel visibility settings with dropdown', async () => {
+			await editorUtils.gotoEditProductPage( productId );
+
+			const rfwBox = editorUtils.getChannelVisibilityMetaBox();
+
+			await expect( rfwBox.getByRole( 'combobox' ) ).toBeVisible();
+
+			await expect(
+				rfwBox.getByText( 'Get your products on Reddit' )
+			).toBeHidden();
+
+			await expect(
+				rfwBox.getByRole( 'button', { name: 'Dismiss' } )
+			).toBeHidden();
+
+			await expect(
+				rfwBox.locator(
+					'.rfw-channel-visibility__get-started--is-dismissed'
+				)
+			).toBeHidden();
+		} );
+
+		test( "Dropdown contains 'Sync and show' and 'Don't sync and show' options", async () => {
+			await editorUtils.gotoEditProductPage( productId );
+
+			const rfwBox = editorUtils.getChannelVisibilityMetaBox();
+			const select = rfwBox.getByRole( 'combobox' );
+			const options = select.locator( 'option' );
+
+			await expect( select ).toBeVisible();
+			await expect( options ).toHaveCount( 2 );
+			await expect( select ).toHaveValue( '1' );
+		} );
+
+		test( 'Changing the dropdown updates the selected value', async () => {
+			await editorUtils.gotoEditProductPage( productId );
+
+			const rfwBox = editorUtils.getChannelVisibilityMetaBox();
+			const select = rfwBox.getByRole( 'combobox' );
+
+			await expect( select ).toBeVisible();
+
+			await select.selectOption( '0' );
+			await expect( select ).toHaveValue( '0' );
+
+			await select.selectOption( '1' );
+			await expect( select ).toHaveValue( '1' );
+		} );
+
+		test( 'Selected visibility value is saved when the product form is submitted', async () => {
+			await editorUtils.gotoEditProductPage( productId );
+
+			const rfwBox = editorUtils.getChannelVisibilityMetaBox();
+			const select = rfwBox.getByRole( 'combobox' );
+
+			await select.selectOption( '0' );
+			await expect( select ).toHaveValue( '0' );
+
+			await editorUtils.save();
+
+			const savedSelect = editorUtils
+				.getChannelVisibilityMetaBox()
+				.getByRole( 'combobox' );
+			await expect( savedSelect ).toHaveValue( '0' );
+
+			await savedSelect.selectOption( '1' );
+			await editorUtils.save();
+		} );
+
+		test( 'Changed visibility value persists after navigating away and back', async () => {
+			await editorUtils.gotoEditProductPage( productId );
+
+			const select = editorUtils
+				.getChannelVisibilityMetaBox()
+				.getByRole( 'combobox' );
+
+			await select.selectOption( '0' );
+			await editorUtils.save();
+
+			await editorUtils.gotoEditProductPage( productId );
+
+			const selectAfterRefresh = editorUtils
+				.getChannelVisibilityMetaBox()
+				.getByRole( 'combobox' );
+
+			await expect( selectAfterRefresh ).toHaveValue( '0' );
+
+			await selectAfterRefresh.selectOption( '1' );
+			await editorUtils.save();
+		} );
+	} );
+} );

--- a/tests/e2e/utils/api.js
+++ b/tests/e2e/utils/api.js
@@ -1,0 +1,114 @@
+/**
+ * REST API utilities for E2E tests.
+ *
+ * Uses axios with HTTP Basic Auth (enabled in the test environment via the
+ * WP-API/Basic-Auth plugin) so API calls work without a browser session.
+ */
+
+/**
+ * External dependencies
+ */
+const axios = require( 'axios' ).default;
+
+/**
+ * Internal dependencies
+ */
+const config = require( '../config/default.json' );
+
+const BASE_URL = `${ config.url }wp-json/`;
+
+const PROMO_NAMESPACE = 'woocommerce/reddit-for-woocommerce';
+const PROMO_KEY = 'channel-visibility-reddit-promo-dismissed';
+
+function makeClient( apiVersion ) {
+	const token = Buffer.from(
+		`${ config.users.admin.username }:${ config.users.admin.password }`,
+		'utf8'
+	).toString( 'base64' );
+
+	return axios.create( {
+		baseURL: `${ BASE_URL }${ apiVersion }/`,
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Basic ${ token }`,
+		},
+	} );
+}
+
+function wcApi() {
+	return makeClient( 'wc/v3' );
+}
+
+function wpApi() {
+	return makeClient( 'wp/v2' );
+}
+
+/**
+ * Creates a simple WooCommerce product via the WC REST API.
+ *
+ * @param {Object} [opts]
+ * @param {string} [opts.name]  Product name.
+ * @param {string} [opts.price] Regular price.
+ * @return {Promise<number>} Product ID.
+ */
+export async function createSimpleProduct( opts = {} ) {
+	const product = config.products.simple;
+
+	const response = await wcApi().post( 'products', {
+		name: opts.name || product.name,
+		regular_price: opts.price || product.regular_price,
+		type: product.type,
+		status: product.status,
+	} );
+
+	return response.data.id;
+}
+
+/**
+ * Permanently deletes a WooCommerce product via the WC REST API.
+ *
+ * @param {number} id Product ID.
+ * @return {Promise<void>}
+ */
+export async function deleteProduct( id ) {
+	await wcApi().delete( `products/${ id }`, { params: { force: true } } );
+}
+
+/**
+ * Sets or clears the promo-dismissed preference for the admin user.
+ *
+ * Uses the standard WP REST API (`wp/v2/users/me`). WooCommerce registers
+ * `persisted_preferences` as a writable user meta field.
+ *
+ * @param {boolean} dismissed
+ * @return {Promise<void>}
+ */
+export async function setPromoDismissed( dismissed ) {
+	const persistedPreferences = dismissed
+		? { [ PROMO_NAMESPACE ]: { [ PROMO_KEY ]: true } }
+		: {};
+
+	await wpApi().put( 'users/me', {
+		meta: { persisted_preferences: persistedPreferences },
+	} );
+}
+
+/**
+ * Sets or clears the Reddit onboarding completion status via the E2E test
+ * endpoint (no standard WP REST API equivalent exists for plugin options).
+ *
+ * @param {boolean} complete
+ * @return {Promise<void>}
+ */
+export async function setOnboardingComplete( complete ) {
+	const client = axios.create( {
+		baseURL: `${ BASE_URL }reddit-e2e/v1/`,
+		headers: { 'Content-Type': 'application/json' },
+	} );
+
+	if ( complete ) {
+		await client.post( 'onboarding-status', { status: 'connected' } );
+	} else {
+		await client.delete( 'onboarding-status' );
+	}
+}

--- a/tests/e2e/utils/product-editor.js
+++ b/tests/e2e/utils/product-editor.js
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import { expect } from '@playwright/test';
+
+/**
+ * Gets E2E test utils for facilitating writing tests for the classic product editor.
+ *
+ * @param {import('@playwright/test').Page} page Playwright page object.
+ */
+export function getClassicProductEditorUtils( page ) {
+	const locators = {
+		getChannelVisibilityMetaBox() {
+			return page.locator( '#channel_visibility' );
+		},
+
+		getChannelVisibilityMetaBoxContent() {
+			return this.getChannelVisibilityMetaBox().locator(
+				'.rfw-channel-visibility__content'
+			);
+		},
+	};
+
+	const asyncActions = {
+		async gotoEditProductPage( id ) {
+			await page.goto( `/wp-admin/post.php?post=${ id }&action=edit` );
+			await this.waitForInteractionReady();
+		},
+
+		waitForInteractionReady() {
+			return expect(
+				page.locator( '.product_data_tabs li.active' )
+			).toHaveCount( 1 );
+		},
+
+		clickSave() {
+			return page
+				.getByRole( 'button', { name: /^(Save Draft|Update)$/ } )
+				.click();
+		},
+
+		async save() {
+			const observer = page.waitForResponse( ( response ) => {
+				const url = new URL( response.url() );
+
+				return (
+					url.pathname === '/wp-admin/post.php' &&
+					url.searchParams.has( 'post' ) &&
+					url.searchParams.has( 'action', 'edit' ) &&
+					response.ok() &&
+					response.request().method() === 'GET'
+				);
+			} );
+
+			await this.clickSave();
+			await observer;
+			await this.waitForInteractionReady();
+		},
+	};
+
+	return { ...locators, ...asyncActions };
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/REDTWOO-137/add-e2e-tests-for-channel-visibility-meta-box

Adds E2E tests to the Channel visibility metabox.


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Install Node and Composer dependencies: `npm install && composer install`
2. Start the containers: `npm run env:start`
3. Run the one-time PHPUnit setup: `npm run test:unit:wp-env:setup`
4. Run the tests: `npm run test:unit:wp-env`

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Add - Channel visibility e2e tests
