### PR TITLE
Added partner + partner version details to Reddit Pixel + CAPI

### DIFF
--- a/includes/Tracking/ConversionEvent/AbstractEventPayloadBase.php
+++ b/includes/Tracking/ConversionEvent/AbstractEventPayloadBase.php
@@ -57,6 +57,17 @@ abstract class AbstractEventPayloadBase implements ConversionCommonPayloadInterf
 	}
 
 	/**
+	 * Retrieves the integration version associated with the payload.
+	 *
+	 * @since 1.0.3
+	 *
+	 * @return string Partner integration version.
+	 */
+	public static function get_partner_version(): string {
+		return REDDIT_FOR_WOOCOMMERCE_VERSION;
+	}
+
+	/**
 	 * Retrieves the Unix timestamp when the event occurred.
 	 *
 	 * Uses the {@see Helper::get_event_time()} utility method to return the

--- a/includes/Tracking/ConversionEvent/AbstractEventPayloadBase.php
+++ b/includes/Tracking/ConversionEvent/AbstractEventPayloadBase.php
@@ -59,7 +59,7 @@ abstract class AbstractEventPayloadBase implements ConversionCommonPayloadInterf
 	/**
 	 * Retrieves the integration version associated with the payload.
 	 *
-	 * @since 1.0.3
+	 * @since 1.0.4
 	 *
 	 * @return string Partner integration version.
 	 */

--- a/includes/Tracking/ConversionEvent/AddToCartEvent.php
+++ b/includes/Tracking/ConversionEvent/AddToCartEvent.php
@@ -187,8 +187,9 @@ final class AddToCartEvent extends AbstractEventPayloadBase implements Conversio
 
 		$payload = array(
 			'data' => array(
-				'partner' => self::get_partner(),
-				'events'  => array( $events ),
+				'partner'         => self::get_partner(),
+				'partner_version' => self::get_partner_version(),
+				'events'          => array( $events ),
 			),
 		);
 

--- a/includes/Tracking/ConversionEvent/Contract/ConversionCommonPayloadInterface.php
+++ b/includes/Tracking/ConversionEvent/Contract/ConversionCommonPayloadInterface.php
@@ -58,7 +58,7 @@ interface ConversionCommonPayloadInterface {
 	 * to send the conversion event. Ad Partners may use it to distinguish
 	 * behavioral changes across platform-managed integrations.
 	 *
-	 * @since 1.0.3
+	 * @since 1.0.4
 	 *
 	 * @return string Partner integration version.
 	 */

--- a/includes/Tracking/ConversionEvent/Contract/ConversionCommonPayloadInterface.php
+++ b/includes/Tracking/ConversionEvent/Contract/ConversionCommonPayloadInterface.php
@@ -52,6 +52,19 @@ interface ConversionCommonPayloadInterface {
 	public static function get_partner(): string;
 
 	/**
+	 * Retrieves the integration version associated with the partner payload.
+	 *
+	 * This value identifies the current plugin/integration release being used
+	 * to send the conversion event. Ad Partners may use it to distinguish
+	 * behavioral changes across platform-managed integrations.
+	 *
+	 * @since 1.0.3
+	 *
+	 * @return string Partner integration version.
+	 */
+	public static function get_partner_version(): string;
+
+	/**
 	 * Retrieves the Unix timestamp when the event occurred.
 	 *
 	 * The timestamp should represent the moment the WooCommerce user action

--- a/includes/Tracking/ConversionEvent/PageVisitEvent.php
+++ b/includes/Tracking/ConversionEvent/PageVisitEvent.php
@@ -74,8 +74,9 @@ final class PageVisitEvent extends AbstractEventPayloadBase implements Conversio
 
 		$payload = array(
 			'data' => array(
-				'partner' => self::get_partner(),
-				'events'  => array( $events ),
+				'partner'         => self::get_partner(),
+				'partner_version' => self::get_partner_version(),
+				'events'          => array( $events ),
 			),
 		);
 

--- a/includes/Tracking/ConversionEvent/PurchaseEvent.php
+++ b/includes/Tracking/ConversionEvent/PurchaseEvent.php
@@ -207,8 +207,9 @@ final class PurchaseEvent extends AbstractEventPayloadBase implements Conversion
 
 		$payload = array(
 			'data' => array(
-				'partner' => self::get_partner(),
-				'events'  => array( $events ),
+				'partner'         => self::get_partner(),
+				'partner_version' => self::get_partner_version(),
+				'events'          => array( $events ),
 			),
 		);
 

--- a/includes/Tracking/ConversionEvent/ViewContentEvent.php
+++ b/includes/Tracking/ConversionEvent/ViewContentEvent.php
@@ -175,8 +175,9 @@ final class ViewContentEvent extends AbstractEventPayloadBase implements Convers
 
 		$payload = array(
 			'data' => array(
-				'partner' => self::get_partner(),
-				'events'  => array( $events ),
+				'partner'         => self::get_partner(),
+				'partner_version' => self::get_partner_version(),
+				'events'          => array( $events ),
 			),
 		);
 

--- a/includes/Tracking/RemotePixelTracker.php
+++ b/includes/Tracking/RemotePixelTracker.php
@@ -37,6 +37,11 @@ use RedditForWooCommerce\Config;
  */
 final class RemotePixelTracker implements PixelTrackerInterface {
 	/**
+	 * Partner identifier expected by Reddit for platform-managed pixel integrations.
+	 */
+	private const PIXEL_PARTNER = 'WOOCOMMERCE';
+
+	/**
 	 * Meta key used to mark orders that have already been tracked.
 	 */
 	protected const ORDER_PIXEL_TRACKED_META_KEY = '_reddit_pixel_tracked';
@@ -146,11 +151,16 @@ final class RemotePixelTracker implements PixelTrackerInterface {
 			return '';
 		}
 
+		$pixel_init_config = array(
+			'partner'         => self::PIXEL_PARTNER,
+			'partner_version' => REDDIT_FOR_WOOCOMMERCE_VERSION,
+		);
+
 		ob_start();
 		?>
 		<!-- Reddit Pixel -->
 		<script>
-		!function(w,d){if(!w.rdt){var p=w.rdt=function(){p.sendEvent?p.sendEvent.apply(p,arguments):p.callQueue.push(arguments)};p.callQueue=[];var t=d.createElement("script");t.src="https://www.redditstatic.com/ads/pixel.js",t.async=!0;var s=d.getElementsByTagName("script")[0];s.parentNode.insertBefore(t,s)}}(window,document);rdt('init', "<?php echo esc_js( $pixel_id ); ?>");
+		!function(w,d){if(!w.rdt){var p=w.rdt=function(){p.sendEvent?p.sendEvent.apply(p,arguments):p.callQueue.push(arguments)};p.callQueue=[];var t=d.createElement("script");t.src="https://www.redditstatic.com/ads/pixel.js",t.async=!0;var s=d.getElementsByTagName("script")[0];s.parentNode.insertBefore(t,s)}}(window,document);rdt('init', "<?php echo esc_js( $pixel_id ); ?>", <?php echo wp_json_encode( $pixel_init_config ); ?>);
 		</script>
 		<!-- DO NOT MODIFY UNLESS TO REPLACE A USER IDENTIFIER -->
 		<!-- End Reddit Pixel -->

--- a/tests/phpunit/Unit/Tracking/ConversionEvent/AddToCartEventTest.php
+++ b/tests/phpunit/Unit/Tracking/ConversionEvent/AddToCartEventTest.php
@@ -65,7 +65,9 @@ final class AddToCartEventTest extends WP_UnitTestCase {
 
 		$this->assertArrayHasKey( 'data', $payload );
 		$this->assertArrayHasKey( 'partner', $payload['data'] );
+		$this->assertArrayHasKey( 'partner_version', $payload['data'] );
 		$this->assertArrayHasKey( 'events', $payload['data'] );
+		$this->assertSame( REDDIT_FOR_WOOCOMMERCE_VERSION, $payload['data']['partner_version'] );
 
 		$events = $payload['data']['events'][0];
 

--- a/tests/phpunit/Unit/Tracking/ConversionEvent/PageVisitEventTest.php
+++ b/tests/phpunit/Unit/Tracking/ConversionEvent/PageVisitEventTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Tests for the PageVisitEvent class.
+ *
+ * @package RedditForWooCommerce\Tests\Unit\Tracking\ConversionEvent
+ */
+
+declare( strict_types=1 );
+
+namespace RedditForWooCommerce\Tests\Unit\Tracking\ConversionEvent;
+
+use RedditForWooCommerce\Tracking\ConversionEvent\PageVisitEvent;
+use RedditForWooCommerce\Utils\UserIdentifier;
+use WP_UnitTestCase;
+
+require_once 'Utils.php';
+
+/**
+ * @covers \RedditForWooCommerce\Tracking\ConversionEvent\PageVisitEvent
+ */
+final class PageVisitEventTest extends WP_UnitTestCase {
+
+	/**
+	 * Set up environment for the test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		r4w_setup_globals();
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tear_down(): void {
+		r4w_destroy_globals();
+		parent::tear_down();
+	}
+
+	/**
+	 * Tests that the payload contains the expected partner metadata.
+	 */
+	public function test_build_payload_contains_partner_version(): void {
+		$event   = new PageVisitEvent();
+		$payload = $event->build_payload(
+			array(
+				'conversion_id' => 'visit_123',
+				'user_data'     => UserIdentifier::get_user_data(),
+			)
+		);
+
+		$this->assertIsArray( $payload );
+		$this->assertArrayHasKey( 'data', $payload );
+		$this->assertSame( 'WOOCOMMERCE', $payload['data']['partner'] );
+		$this->assertSame( REDDIT_FOR_WOOCOMMERCE_VERSION, $payload['data']['partner_version'] );
+		$this->assertArrayHasKey( 'events', $payload['data'] );
+
+		$events = $payload['data']['events'][0];
+
+		$this->assertSame( 'WEBSITE', $events['action_source'] );
+		$this->assertSame( 'PAGE_VISIT', $events['type']['tracking_type'] );
+		$this->assertSame( 'visit_123', $events['metadata']['conversion_id'] );
+	}
+}

--- a/tests/phpunit/Unit/Tracking/ConversionEvent/PurchaseEventTest.php
+++ b/tests/phpunit/Unit/Tracking/ConversionEvent/PurchaseEventTest.php
@@ -82,7 +82,9 @@ class PurchaseEventTest extends WP_UnitTestCase {
 
 		$this->assertArrayHasKey( 'data', $payload );
 		$this->assertArrayHasKey( 'partner', $payload['data'] );
+		$this->assertArrayHasKey( 'partner_version', $payload['data'] );
 		$this->assertArrayHasKey( 'events', $payload['data'] );
+		$this->assertSame( REDDIT_FOR_WOOCOMMERCE_VERSION, $payload['data']['partner_version'] );
 
 		$events = $payload['data']['events'][0];
 

--- a/tests/phpunit/Unit/Tracking/ConversionEvent/ViewContentEventTest.php
+++ b/tests/phpunit/Unit/Tracking/ConversionEvent/ViewContentEventTest.php
@@ -46,7 +46,9 @@ class ViewContentEventTest extends TestCase {
 
 		$this->assertArrayHasKey( 'data', $payload );
 		$this->assertArrayHasKey( 'partner', $payload['data'] );
+		$this->assertArrayHasKey( 'partner_version', $payload['data'] );
 		$this->assertArrayHasKey( 'events', $payload['data'] );
+		$this->assertSame( REDDIT_FOR_WOOCOMMERCE_VERSION, $payload['data']['partner_version'] );
 
 		$events = $payload['data']['events'][0];
 

--- a/tests/phpunit/Unit/Tracking/RemotePixelTrackerTest.php
+++ b/tests/phpunit/Unit/Tracking/RemotePixelTrackerTest.php
@@ -27,6 +27,7 @@ class RemotePixelTrackerTest extends WP_UnitTestCase {
 
 		// Enable pixel tracking.
 		Options::set( OptionDefaults::PIXEL_ENABLED, 'yes' );
+		Options::set( OptionDefaults::PIXEL_ID, 'pixel-123' );
 
 		// Provide a dummy ad account ID for API path construction.
 		Options::set( OptionDefaults::AD_ACCOUNT_ID, 'fake-account-id' );
@@ -36,6 +37,7 @@ class RemotePixelTrackerTest extends WP_UnitTestCase {
 
 	public function tear_down(): void {
 		Options::delete( OptionDefaults::PIXEL_ENABLED );
+		Options::delete( OptionDefaults::PIXEL_ID );
 		Options::delete( OptionDefaults::AD_ACCOUNT_ID );
 		remove_filter( Helper::with_prefix( 'filter_pixel_script' ), array( $this, 'mock_script' ) );
 
@@ -61,5 +63,23 @@ class RemotePixelTrackerTest extends WP_UnitTestCase {
 
 		$this->assertStringContainsString( '<script', $output );
 		$this->assertStringContainsString( 'scevent.min.js', $output );
+	}
+
+	public function test_maybe_inject_pixel_outputs_partner_config_in_generated_script() {
+		remove_filter( Helper::with_prefix( 'filter_pixel_script' ), array( $this, 'mock_script' ) );
+
+		$wcs     = $this->createMock( WcsClient::class );
+		$tracker = new RemotePixelTracker( $wcs );
+
+		ob_start();
+		$tracker->maybe_inject_pixel();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'rdt(\'init\', "pixel-123", {', $output );
+		$this->assertStringContainsString( '"partner":"WOOCOMMERCE"', $output );
+		$this->assertStringContainsString(
+			'"partner_version":"' . REDDIT_FOR_WOOCOMMERCE_VERSION . '"',
+			$output
+		);
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

This version adds the partner and partner version to the Reddit Pixel payload, and partner version for CAPI. 

Closes REDTWOO-148

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Ensure that tracking is enabled and visit any page in the store.
2. In the DOM, search for: `rdt('init'`
3. Ensure that you see the partner and partner version fields there.

### Changelog entry

> Dev - Added partner details to Reddit's Pixel + CAPI requests.
