### PR TITLE
REDTWOO-130 show Reddit components on product and order

### DIFF
--- a/includes/Admin/MetaBox/MetaBoxRegistration.php
+++ b/includes/Admin/MetaBox/MetaBoxRegistration.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * Registers standalone Reddit meta boxes on product and order edit screens
+ * when third-party plugins (e.g. Google Listings & Ads) that normally provide
+ * the mount containers are inactive.
+ *
+ * @package RedditForWooCommerce\Admin\MetaBox
+ * @since 0.1.0
+ */
+
+namespace RedditForWooCommerce\Admin\MetaBox;
+
+use Automattic\WooCommerce\Utilities\OrderUtil;
+
+/**
+ * Provides fallback PHP meta boxes so JS bundles always have a DOM mount point.
+ *
+ * When GLA is active it supplies:
+ *  - `#channel_visibility .inside`  → channel-visibility bundle mount point on Edit Product.
+ *  - The WooCommerce order-attribution panel enhancements → order-attribution bundle mount
+ *    point on Edit Order.
+ *
+ * When GLA is inactive those elements are absent and the JS bundles return early without
+ * rendering anything. This class registers lightweight Reddit meta boxes in their place so
+ * the JS always has a container to mount into.
+ *
+ * @since 0.1.0
+ */
+class MetaBoxRegistration {
+
+	/**
+	 * GLA plugin basename used for active-plugin detection.
+	 *
+	 * @since 0.1.0
+	 */
+	const GLA_PLUGIN = 'google-listings-and-ads/google-listings-and-ads.php';
+
+	/**
+	 * Registers hooks.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @return void
+	 */
+	public function register_hooks(): void {
+		add_action( 'add_meta_boxes', array( $this, 'maybe_register_product_meta_box' ) );
+		add_action( 'add_meta_boxes', array( $this, 'maybe_register_order_meta_box' ) );
+	}
+
+	/**
+	 * Registers a Reddit meta box on the product edit screen when GLA is inactive.
+	 *
+	 * GLA's "Channel visibility" meta box (`#channel_visibility`) is the default mount
+	 * container used by the channel-visibility JS bundle. When GLA is inactive that
+	 * element is absent, so we register our own box which renders the
+	 * `#reddit-channel-visibility-box` div the JS already looks for first.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @return void
+	 */
+	public function maybe_register_product_meta_box(): void {
+		if ( $this->is_gla_active() ) {
+			return;
+		}
+
+		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+
+		if ( null === $screen || 'product' !== $screen->id ) {
+			return;
+		}
+
+		add_meta_box(
+			'reddit-channel-visibility',
+			__( 'Reddit', 'reddit-for-woocommerce' ),
+			array( $this, 'render_channel_visibility_meta_box' ),
+			'product',
+			'side'
+		);
+	}
+
+	/**
+	 * Registers a Reddit meta box on the order edit screen when GLA is inactive.
+	 *
+	 * When GLA is inactive the order attribution panel enhancements that the
+	 * order-attribution JS bundle hooks into are not rendered. This meta box
+	 * provides the `#reddit-order-attribution-box` div the JS falls back to.
+	 *
+	 * Registered on both the CPT (`shop_order`) and HPOS (`woocommerce_page_wc-orders`)
+	 * order edit screens.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @return void
+	 */
+	public function maybe_register_order_meta_box(): void {
+		if ( $this->is_gla_active() ) {
+			return;
+		}
+
+		if ( ! class_exists( OrderUtil::class ) || ! OrderUtil::is_order_edit_screen() ) {
+			return;
+		}
+
+		add_meta_box(
+			'reddit-order-attribution',
+			__( 'Reddit', 'reddit-for-woocommerce' ),
+			array( $this, 'render_order_attribution_meta_box' ),
+			array( 'shop_order', 'woocommerce_page_wc-orders' ),
+			'side'
+		);
+	}
+
+	/**
+	 * Renders the channel-visibility meta box content.
+	 *
+	 * The `#reddit-channel-visibility-box` div is the primary mount point checked by
+	 * the channel-visibility JS bundle (js/src/meta-boxes/channel-visibility/index.js).
+	 *
+	 * @since 0.1.0
+	 *
+	 * @return void
+	 */
+	public function render_channel_visibility_meta_box(): void {
+		printf( '<div id="%s"></div>', esc_attr( 'reddit-channel-visibility-box' ) );
+	}
+
+	/**
+	 * Renders the order-attribution meta box content.
+	 *
+	 * The `#reddit-order-attribution-box` div is the fallback mount point checked by
+	 * the order-attribution JS bundle (js/src/meta-boxes/order-attribution/index.js).
+	 *
+	 * @since 0.1.0
+	 *
+	 * @return void
+	 */
+	public function render_order_attribution_meta_box(): void {
+		printf( '<div id="%s"></div>', esc_attr( 'reddit-order-attribution-box' ) );
+	}
+
+	/**
+	 * Whether Google Listings & Ads is currently active.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @return bool
+	 */
+	private function is_gla_active(): bool {
+		return function_exists( 'is_plugin_active' ) && is_plugin_active( self::GLA_PLUGIN );
+	}
+}

--- a/includes/ServiceContainer.php
+++ b/includes/ServiceContainer.php
@@ -114,6 +114,7 @@ final class ServiceContainer {
 					new Admin\Menu(),
 					new Admin\Onboarding(),
 					new Admin\MetaBox\MetaBoxAssets(),
+					new Admin\MetaBox\MetaBoxRegistration(),
 					new ProductMeta\ProductMetaFields(),
 				);
 

--- a/js/src/meta-boxes/order-attribution/index.js
+++ b/js/src/meta-boxes/order-attribution/index.js
@@ -22,9 +22,15 @@ domReady( () => {
 		'#woocommerce-order-source-data .woocommerce-order-attribution-details-container'
 	);
 	// Fallback container rendered by MetaBoxRegistration when GLA is inactive.
-	const standaloneBox = document.getElementById( 'reddit-order-attribution-box' );
+	const standaloneBox = document.getElementById(
+		'reddit-order-attribution-box'
+	);
 
-	if ( ! orderAttributionDetailsContainer && ! orderAttributionBox && ! standaloneBox ) {
+	if (
+		! orderAttributionDetailsContainer &&
+		! orderAttributionBox &&
+		! standaloneBox
+	) {
 		return;
 	}
 

--- a/js/src/meta-boxes/order-attribution/index.js
+++ b/js/src/meta-boxes/order-attribution/index.js
@@ -21,8 +21,10 @@ domReady( () => {
 	const orderAttributionDetailsContainer = document.querySelector(
 		'#woocommerce-order-source-data .woocommerce-order-attribution-details-container'
 	);
+	// Fallback container rendered by MetaBoxRegistration when GLA is inactive.
+	const standaloneBox = document.getElementById( 'reddit-order-attribution-box' );
 
-	if ( ! orderAttributionDetailsContainer && ! orderAttributionBox ) {
+	if ( ! orderAttributionDetailsContainer && ! orderAttributionBox && ! standaloneBox ) {
 		return;
 	}
 
@@ -44,5 +46,10 @@ domReady( () => {
 		return;
 	}
 
-	orderAttributionBox.prepend( rfwElement );
+	if ( orderAttributionBox ) {
+		orderAttributionBox.prepend( rfwElement );
+		return;
+	}
+
+	standaloneBox.appendChild( rfwElement );
 } );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes:
- [REDTWOO-134](https://linear.app/a8c/issue/REDTWOO-134/channelvisibilitysettings-component)
- [REDTWOO-133](https://linear.app/a8c/issue/REDTWOO-133/redditadspromo-component-channel-visibility-context)
- [REDTWOO-132](https://linear.app/a8c/issue/REDTWOO-132/channel-visibility-mount-point-with-mode-aware-injection)
- [REDTWOO-131](https://linear.app/a8c/issue/REDTWOO-131/redditadspromo-component-order-attribution-context)
- [REDTWOO-130](https://linear.app/a8c/issue/REDTWOO-130/order-attribution-mount-point)

When Google Listings & Ads is inactive, the DOM containers that the channel-visibility and order-attribution JS bundles rely on are absent, so the components silently bail without mounting.

Add `MetaBoxRegistration` to register lightweight fallback PHP meta boxes on the product and order edit screens when GLA is inactive:
- **Product page**: renders `#reddit-channel-visibility-box` (already the primary selector in `channel-visibility/index.js`)
- **Order page**: renders `#reddit-order-attribution-box` (new fallback)

Update `order-attribution/index.js` to try `#reddit-order-attribution-box` as a last resort after the two `#woocommerce-order-source-data` selectors.

Wire `MetaBoxRegistration` into `Admin\Setup` via `ServiceContainer`.


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

**Case-1. Plugin installed and fully setup**
1. Install and setup the plugin
2. Visit an order with Reddit source
3. Verify that the Reddit component is present in the "Order attribution" box

**Case-2. GLA plugin inactive**
1. Install and setup the Reddit plugin
2. Disable the GLA plugin
3. Verify that in the Product and Order page the Reddit component is correctly showing

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
