### PR TITLE
REDTWOO-146: Update CI workflows for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,15 +20,15 @@ jobs:
       FORCE_COLOR: 2
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@da5279aa4d76745ef32970e49b5ef7903a3b457a # v2.2.2
+        uses: woocommerce/grow/prepare-php@actions-v3
         with:
           install-deps: "no"
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@da5279aa4d76745ef32970e49b5ef7903a3b457a # v2.2.2
+        uses: woocommerce/grow/prepare-node@actions-v3
         with:
           node-version-file: ".nvmrc"
           ignore-scripts: "no"
@@ -41,13 +41,13 @@ jobs:
 
       - name: Publish dev build to GitHub
         if: ${{ github.event_name == 'push' && github.ref_name == 'develop' }}
-        uses: woocommerce/grow/publish-extension-dev-build@da5279aa4d76745ef32970e49b5ef7903a3b457a # v2.2.2
+        uses: woocommerce/grow/publish-extension-dev-build@actions-v3
         with:
           extension-asset-path: reddit-for-woocommerce.zip
 
       - name: Publish build artifact
         if: ${{ ! ( github.event_name == 'push' && github.ref_name == 'develop' ) }}
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        uses: actions/upload-artifact@v5
         with:
           name: reddit-for-woocommerce.zip
           path: ${{ github.workspace }}/reddit-for-woocommerce.zip

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       # Checkout the private action repository
       - name: Checkout woo-product-deploy action
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # 4.3.0
+        uses: actions/checkout@v6
         with:
           repository: woocommerce/woo-product-deploy
           ref: trunk
@@ -69,7 +69,7 @@ jobs:
           fi
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        uses: actions/upload-artifact@v5
         with:
           name: reddit-for-woocommerce.zip
           path: ${{ github.workspace }}/reddit-for-woocommerce.zip

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -24,14 +24,14 @@ jobs:
       FORCE_COLOR: 2
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
 
-      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # 4.3.0
+      - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
 
       - name: Composer cache
-        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+        uses: actions/cache@v5
         with:
           path: |
             vendor
@@ -39,7 +39,7 @@ jobs:
           key: composer-${{ hashFiles('composer.lock') }}
 
       - name: Node cache
-        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -77,7 +77,7 @@ jobs:
           github.event_name == 'pull_request' &&
           always() &&
           steps.e2e_tests.conclusion == 'success'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@v8
         continue-on-error: true
         with:
           script: |
@@ -100,7 +100,7 @@ jobs:
           github.event_name == 'pull_request' &&
           always() &&
           steps.e2e_tests.conclusion == 'failure'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@v8
         continue-on-error: true
         with:
           script: |
@@ -117,7 +117,7 @@ jobs:
               labels: ['status: e2e tests failing']
             })
 
-      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+      - uses: actions/upload-artifact@v5
         if: always()
         with:
           name: playwright-report

--- a/.github/workflows/js-css-linting.yml
+++ b/.github/workflows/js-css-linting.yml
@@ -28,15 +28,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@da5279aa4d76745ef32970e49b5ef7903a3b457a # v2.2.2
+        uses: woocommerce/grow/prepare-node@actions-v3
         with:
           node-version-file: ".nvmrc"
 
       - name: Prepare annotation formatter
-        uses: woocommerce/grow/eslint-annotation@actions-v2
+        uses: woocommerce/grow/eslint-annotation@actions-v3
 
       - name: Lint JavaScript and annotate linting errors
         run: npm run lint:js
@@ -46,15 +46,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@da5279aa4d76745ef32970e49b5ef7903a3b457a # v2.2.2
+        uses: woocommerce/grow/prepare-node@actions-v3
         with:
           node-version-file: ".nvmrc"
 
       - name: Prepare annotation formatter
-        uses: woocommerce/grow/stylelint-annotation@actions-v2
+        uses: woocommerce/grow/stylelint-annotation@actions-v3
 
       - name: Lint CSS and annotate linting errors
         run: npm run lint:css -- --custom-formatter ./stylelintFormatter.cjs

--- a/.github/workflows/js-unit-tests.yml
+++ b/.github/workflows/js-unit-tests.yml
@@ -29,10 +29,10 @@ jobs:
       FORCE_COLOR: 2
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@da5279aa4d76745ef32970e49b5ef7903a3b457a # v2.2.2
+        uses: woocommerce/grow/prepare-node@actions-v3
         with:
           node-version-file: ".nvmrc"
 
@@ -40,7 +40,7 @@ jobs:
         run: npm run test:js
 
       - name: Upload JS unit coverage report
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
+        uses: codecov/codecov-action@aa56896cf108bd10b5eb883cd1d24196da57f695 # v5.5.4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage/clover.xml

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -27,10 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@da5279aa4d76745ef32970e49b5ef7903a3b457a # v2.2.2
+        uses: woocommerce/grow/prepare-php@actions-v3
         with:
           tools: cs2pr
 
@@ -45,16 +45,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@da5279aa4d76745ef32970e49b5ef7903a3b457a # v2.2.2
+        uses: woocommerce/grow/prepare-php@actions-v3
         with:
           tools: cs2pr
           install-deps: no
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@da5279aa4d76745ef32970e49b5ef7903a3b457a # v2.2.2
+        uses: woocommerce/grow/prepare-node@actions-v3
         with:
           node-version-file: ".nvmrc"
           ignore-scripts: "no"

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -36,17 +36,17 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
 
       - name: Set up PHP ${{ matrix.php-version }}
-        uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
           extensions: mbstring, mysqli
           tools: composer, phpunit
 
       - name: Prepare MySQL
-        uses: woocommerce/grow/prepare-mysql@da5279aa4d76745ef32970e49b5ef7903a3b457a # v2.2.2
+        uses: woocommerce/grow/prepare-mysql@actions-v3
 
       - name: Install svn (used for installing WP versions)
         run: sudo apt-get -y install subversion

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -27,10 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
 
       - name: Create branch & PR
-        uses: woocommerce/grow/prepare-extension-release@actions-v2
+        uses: woocommerce/grow/prepare-extension-release@actions-v3
         with:
           version: ${{ github.event.inputs.version }}
           type: ${{ github.event.inputs.type }}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes [REDTWOO-146](https://linear.app/a8c/issue/REDTWOO-146/update-github-actions-to-node-24-reddit-for-woocommerce).

GitHub runners began defaulting to Node 24 on June 16, 2026, deprecating Node 20 actions. This PR updates all workflows in this repo to be Node 24-compatible.


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. No node20 deprecation warnings in any workflow run after merging — previously shown as yellow annotations, should be gone across all 8 workflows.
2. `js-unit-tests` — verify the codecov upload step completes without errors.
3. `php-unit-tests` — verify PHPUnit runs across the full PHP matrix (7.4–8.4) and setup-php still resolves correctly.
4. `js-css-linting`, `php-coding-standards`, `build` — trigger via a test PR/push and confirm they pass.
5. `e2e-tests` — confirm Playwright run completes, including the label-update and artifact-upload steps.
6. `deploy.yml` / `prepare-release.yml` — these are `workflow_dispatch` only; a dry run (`simulate: true`) is enough to confirm no syntax/reference errors.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - Update CI workflows for Node.js 24 compatibility
